### PR TITLE
Enforce image height and width from 0-4096 pixels

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,8 +329,8 @@ All fields except `prompt` are optional. Omitted fields use the loaded model's d
 |-------|------|---------|-------------|
 | `prompt` | `string` | *(required)* | Text prompt |
 | `negative_prompt` | `string` | `""` | Negative prompt |
-| `width` | `int` | model default | Output width in pixels (0..1024) |
-| `height` | `int` | model default | Output height in pixels (0..1024) |
+| `width` | `int` | model default | Output width in pixels (0..4096) |
+| `height` | `int` | model default | Output height in pixels (0..4096) |
 | `steps` | `int` | model default | Number of denoising steps |
 | `guidance_scale` | `float` | model default | CFG scale (≤ 1.0 disables CFG) |
 | `seed` | `int` | random | Random seed (`-1` for random) |

--- a/README.md
+++ b/README.md
@@ -329,8 +329,8 @@ All fields except `prompt` are optional. Omitted fields use the loaded model's d
 |-------|------|---------|-------------|
 | `prompt` | `string` | *(required)* | Text prompt |
 | `negative_prompt` | `string` | `""` | Negative prompt |
-| `width` | `int` | model default | Output width in pixels |
-| `height` | `int` | model default | Output height in pixels |
+| `width` | `int` | model default | Output width in pixels (0..1024) |
+| `height` | `int` | model default | Output height in pixels (0..1024) |
 | `steps` | `int` | model default | Number of denoising steps |
 | `guidance_scale` | `float` | model default | CFG scale (≤ 1.0 disables CFG) |
 | `seed` | `int` | random | Random seed (`-1` for random) |

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -56,12 +56,12 @@ def test_upscalers_available_without_model():
 def test_text2image_passes_pixel_upscaler(tmp_path):
     runtime = _fake_runtime(tmp_path)
     app = create_app(runtime)
-    req = Text2ImageRequest(prompt="a fox", pixel_upscaler="RealESRGAN_x4")
+    req = Text2ImageRequest(prompt="a fox", width=512, height=512, pixel_upscaler="RealESRGAN_x4")
     res = _endpoint(app, "/text2image")(req)
     assert res.status_code == 200
     assert runtime._pipeline.last_request.pixel_upscaler == "RealESRGAN_x4"
 
 
 def test_request_field_defaults_none():
-    req = Text2ImageRequest(prompt="x")
+    req = Text2ImageRequest(prompt="x", width=512, height=512)
     assert req.pixel_upscaler is None

--- a/thenoise/api.py
+++ b/thenoise/api.py
@@ -31,15 +31,6 @@ class Text2ImageRequest(BaseModel):
     width: Optional[int] = None
     height: Optional[int] = None
 
-    @property
-    def _max_dim(self) -> int:
-        return 1024
-
-    def model_post_init(self, __context) -> None:
-        max_dim = self._max_dim
-        for name, value in (("width", self.width), ("height", self.height)):
-            if value is not None and (value < 0 or value > max_dim):
-                raise ValueError(f"{name} must be between 0 and {max_dim} (got {value}).")
     steps: Optional[int] = None
     guidance_scale: Optional[float] = None
     seed: Optional[int] = None

--- a/thenoise/api.py
+++ b/thenoise/api.py
@@ -30,6 +30,16 @@ class Text2ImageRequest(BaseModel):
     negative_prompt: str = ""
     width: Optional[int] = None
     height: Optional[int] = None
+
+    @property
+    def _max_dim(self) -> int:
+        return 1024
+
+    def model_post_init(self, __context) -> None:
+        max_dim = self._max_dim
+        for name, value in (("width", self.width), ("height", self.height)):
+            if value is not None and (value < 0 or value > max_dim):
+                raise ValueError(f"{name} must be between 0 and {max_dim} (got {value}).")
     steps: Optional[int] = None
     guidance_scale: Optional[float] = None
     seed: Optional[int] = None

--- a/thenoise/generate.py
+++ b/thenoise/generate.py
@@ -9,12 +9,21 @@ from __future__ import annotations
 import logging
 import os
 import random
+import sys
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
 def run_generate(args) -> None:
+    _MAX_DIM = 1024
+    if args.width is not None and (args.width < 0 or args.width > _MAX_DIM):
+        print(f"error: width must be between 0 and {_MAX_DIM} (got {args.width}).", file=sys.stderr)
+        sys.exit(1)
+    if args.height is not None and (args.height < 0 or args.height > _MAX_DIM):
+        print(f"error: height must be between 0 and {_MAX_DIM} (got {args.height}).", file=sys.stderr)
+        sys.exit(1)
+
     from .models.config import GenerateRequest
     from .runtime import Settings, ModelPaths, Runtime
     settings = Settings(device=args.device)

--- a/thenoise/generate.py
+++ b/thenoise/generate.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 def run_generate(args) -> None:
-    _MAX_DIM = 1024
+    _MAX_DIM = 4096
     if args.width is not None and (args.width < 0 or args.width > _MAX_DIM):
         print(f"error: width must be between 0 and {_MAX_DIM} (got {args.width}).", file=sys.stderr)
         sys.exit(1)

--- a/thenoise/ui/index.html
+++ b/thenoise/ui/index.html
@@ -242,13 +242,13 @@
     <div class="field">
       <label for="width">Width</label>
       <input type="number" id="width" placeholder="auto" value="1024">
-      <span class="hint">Max 1024</span>
+      <span class="hint">Max 4096</span>
     </div>
     <button class="swap" id="swap" title="Swap width and height" aria-label="Swap width and height">&#8646;</button>
     <div class="field">
       <label for="height">Height</label>
       <input type="number" id="height" placeholder="auto" value="1024">
-      <span class="hint">Max 1024</span>
+      <span class="hint">Max 4096</span>
     </div>
   </div>
 
@@ -745,6 +745,18 @@ $('generate').addEventListener('click', async () => {
   }
   const samplerVal = $('sampler').value;
   if (samplerVal) body.sampler = samplerVal;
+
+  const MAX_DIM = 4096;
+  for (const f of ['width', 'height']) {
+    const v = $(f).value === '' ? null : parseInt($(f).value, 10);
+    if (v !== null && (v < 0 || v > MAX_DIM)) {
+      btn.disabled = false;
+      clearInterval(timer);
+      overlay.classList.add('hidden');
+      alert(`error: ${f} must be between 0 and ${MAX_DIM} (got ${v}).`);
+      return;
+    }
+  }
 
   try {
     const res = await fetch('/text2image', {

--- a/thenoise/ui/index.html
+++ b/thenoise/ui/index.html
@@ -242,11 +242,13 @@
     <div class="field">
       <label for="width">Width</label>
       <input type="number" id="width" placeholder="auto" value="1024">
+      <span class="hint">Max 1024</span>
     </div>
     <button class="swap" id="swap" title="Swap width and height" aria-label="Swap width and height">&#8646;</button>
     <div class="field">
       <label for="height">Height</label>
       <input type="number" id="height" placeholder="auto" value="1024">
+      <span class="hint">Max 1024</span>
     </div>
   </div>
 


### PR DESCRIPTION
0 is treated as model default, and anything over 1024 is an error. CLI, API, and WUI all enforce these and give useful errors.

I went with 1024 as the upper limit since I have no evidence that any models are trained on larger inputs; the internet says to use upscaling if you want larger images

Fixes #11 