### PR TITLE
Add an image gallery feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ LoRA format is `filename:weight` — the `.safetensors` extension is appended au
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/` | Web UI |
+| `GET` | `/gallery` | List images in the persistent gallery, if available |
 | `GET` | `/health` | Server status and loaded model |
 | `GET` | `/lora` | List available LoRA names |
 | `GET` | `/upscalers` | List available pixel upscaler names |
@@ -380,6 +381,7 @@ If no model is loaded, `/text2image` returns HTTP 503.
 | `--host` | `127.0.0.1` | Bind host |
 | `--port` | `8000` | Bind port |
 | `--upscaler-dir` | — | Directory containing pixel upscaler `.safetensors` files (e.g. Real-ESRGAN); selected per-request via `pixel_upscaler` |
+| `--gallery` | — | Directory to use as a persistent image store. If enabled, it also displays previously saved images |
 
 ### `generate` only
 

--- a/thenoise/__main__.py
+++ b/thenoise/__main__.py
@@ -5,10 +5,14 @@ from .cli import build_parser
 
 
 def _serve(args) -> None:
+    import logging
+    logging.basicConfig(level=logging.INFO)
+
     from .runtime import Settings, ModelPaths, Runtime
     settings = Settings(
         device=args.device, host=args.host, port=args.port,
         upscaler_dir=args.upscaler_dir,
+        gallery_dir=args.gallery,
     )
 
     runtime = Runtime(settings)
@@ -22,9 +26,10 @@ def _serve(args) -> None:
     )
 
     from .api import create_app
+    from .api import Gallery
     import uvicorn
 
-    app = create_app(runtime)
+    app = create_app(runtime, gallery=Gallery(settings.gallery_dir))
     print(f"thenoise serving model '{runtime.model_name}' on {settings.device}")
     uvicorn.run(app, host=settings.host, port=settings.port)
 

--- a/thenoise/api.py
+++ b/thenoise/api.py
@@ -7,23 +7,210 @@ A per-model inference lock serializes concurrent requests.
 The request carries only the shared, model-agnostic parameters. Per-model defaults
 (including the "advanced" sampler params) are owned by the model class and are NOT
 exposed here.
+
+Gallery support
+---------------
+When ``gallery_dir`` is set (via ``--gallery``), every generated image is saved
+to that directory and served via ``/gallery-images/<filename>``.
+The ``/gallery`` endpoint returns a list of images for the persistent gallery,
+which is scanned at startup so images survive restarts.
 """
 from __future__ import annotations
 
 import io
+import json
 import logging
 import os
+import random
 import base64
-from typing import List, Literal, Optional
+from datetime import datetime, timezone
+from typing import Any, List, Literal, Optional
 
 from fastapi import FastAPI
-from fastapi.responses import HTMLResponse, Response
+from fastapi.responses import HTMLResponse, JSONResponse, Response
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
 _UI_DIR = os.path.join(os.path.dirname(__file__), "ui")
 
+
+def _parse_gen_data(pnginfo: Any) -> dict | None:
+    """Extract generation_data JSON from a PIL ``PngInfo`` metadata object or ``info`` dict."""
+    if pnginfo is None:
+        return None
+    try:
+        # Handle PIL PngInfo object (from build_pnginfo / _pnginfo)
+        if hasattr(pnginfo, "chunks"):
+            for ctype, data, _comp in pnginfo.chunks:
+                if ctype != b"tEXt":
+                    continue
+                null_idx = data.find(b"\x00")
+                if null_idx < 0:
+                    continue
+                keyword = data[:null_idx]
+                if keyword == b"generation_data":
+                    raw = data[null_idx + 1:]
+                    return json.loads(raw.decode("latin-1", errors="replace"))
+        # Handle .info dict (from Image.open().info)
+        raw = getattr(pnginfo, "get", lambda _: None)("generation_data")
+        if raw is None:
+            return None
+        if isinstance(raw, bytes):
+            return json.loads(raw.decode("latin-1", errors="replace"))
+        if isinstance(raw, str):
+            return json.loads(raw)
+        return None
+    except Exception:
+        return None
+
+
+class Gallery:
+    """Thread-safe file-based gallery backed by metadata in saved PNGs.
+
+    Images are saved with the prompt metadata embedded in the PNG (``tEXt``
+    chunks) and kept in an in-memory cache for fast ``/gallery`` responses.
+    """
+
+    def __init__(self, gallery_dir: str) -> None:
+        self.gallery_dir = gallery_dir
+        self._cache: dict[str, dict] = {}
+
+    @property
+    def active(self) -> bool:
+        return bool(self.gallery_dir)
+
+    @staticmethod
+    def _read_meta(gallery_dir: str, fname: str) -> dict | None:
+        try:
+            from PIL import Image
+            img = Image.open(os.path.join(gallery_dir, fname))
+            meta = _parse_gen_data(img.info)
+            img.close()
+            return meta
+        except Exception:
+            return None
+
+    # -- initial load ---------------------------------------------------------
+
+    def initialize(self) -> None:
+        """Scan the gallery directory and extract metadata from existing images."""
+        if not self.active:
+            return
+        try:
+            filenames = sorted(
+                f for f in os.listdir(self.gallery_dir)
+                if f.lower().endswith(".png")
+            )
+        except FileNotFoundError:
+            return
+        for fname in filenames:
+            meta = self._read_meta(self.gallery_dir, fname)
+            if meta:
+                self._cache[fname] = meta
+
+    # -- save -----------------------------------------------------------------
+
+    def save(self, image: Any) -> str | None:
+        """Save *image* to the gallery and cache its metadata.
+
+        Returns the filename (for ``currentUrl``) or ``None`` on failure.
+        """
+        if not self.active:
+            return None
+        pnginfo = getattr(image, "_pnginfo", None)
+        meta = _parse_gen_data(pnginfo) if pnginfo else None
+        if not self.gallery_dir:
+            return None
+
+        # Ensure directory exists or create it
+        gallery_dir = os.path.abspath(self.gallery_dir)
+        try:
+            os.makedirs(gallery_dir, exist_ok=True)
+        except OSError:
+            logger.exception("gallery: cannot create directory %s", gallery_dir)
+            return None
+        for _ in range(5):
+            if meta:
+                fname = (
+                    f"{datetime.now(timezone.utc).timestamp():010.3f}_"
+                    f"{random.randint(0, 9999):04d}_"
+                    f"{meta.get('seed', 'x')}.png"
+                )
+            else:
+                fname = (
+                    f"{datetime.now(timezone.utc).timestamp():010.3f}_"
+                    f"{random.randint(0, 9999):04d}.png"
+                )
+            dest = os.path.join(gallery_dir, fname)
+            if not os.path.exists(dest):
+                break
+        else:
+            return None
+        try:
+            image.save(dest, format="PNG", pnginfo=pnginfo)
+            if meta:
+                self._cache[fname] = meta
+            return fname
+        except Exception:
+            logger.exception("gallery: failed to save %s", fname)
+            return None
+
+    # -- list ------------------------------------------------------------------
+
+    def list_images(self) -> list[dict]:
+        """Return list of {filename, url, meta} dicts, newest first."""
+        if not self.active:
+            return []
+        now = set(self._cache.keys())
+        try:
+            on_disk = frozenset(
+                f for f in os.listdir(self.gallery_dir)
+                if f.lower().endswith(".png")
+            )
+        except FileNotFoundError:
+            on_disk = frozenset()
+        stale = now - on_disk
+        if stale:
+            for s in stale:
+                self._cache.pop(s, None)
+        fresh = on_disk - now
+        if fresh:
+            for f in list(fresh)[:50]:
+                m = self._read_meta(self.gallery_dir, f)
+                if m:
+                    self._cache[f] = m
+        order = sorted(self._cache, reverse=True)
+        return [
+            {"filename": f, "url": f"/gallery-images/{f}", "meta": self._cache[f]}
+            for f in order
+        ]
+
+    # -- image serving ---------------------------------------------------------
+
+    def serve(self, filename: str) -> Response | JSONResponse:
+        """Return the raw PNG for *filename*, or a 404."""
+        if not self.active:
+            return JSONResponse(status_code=404, content="gallery not configured")
+        safe = os.path.basename(filename)
+        gallery_abs = os.path.abspath(self.gallery_dir)
+        path = os.path.join(gallery_abs, safe)
+        abs_path = os.path.abspath(path)
+        if not (abs_path.startswith(gallery_abs) and (
+            abs_path == gallery_abs or abs_path.startswith(gallery_abs + os.sep)
+        )):
+            return JSONResponse(status_code=404, content="not found")
+        if not os.path.isfile(path):
+            return JSONResponse(status_code=404, content="not found")
+        try:
+            data = open(path, "rb").read()
+            return Response(content=data, media_type="image/png")
+        except OSError:
+            return JSONResponse(status_code=404, content="not found")
+
+
+# ---------------------------------------------------------------------------
+# Request model & app factory
 
 class Text2ImageRequest(BaseModel):
     prompt: str
@@ -68,8 +255,12 @@ class Text2ImageRequest(BaseModel):
         )
 
 
-def create_app(runtime) -> FastAPI:
+def create_app(runtime, gallery: Gallery | None = None) -> FastAPI:
     app = FastAPI(title="thenoise", version="0.1.0")
+
+    if gallery is not None and gallery.active:
+        gallery.initialize()
+        logger.info("gallery initialized with %d images from %s", len(gallery._cache), gallery.gallery_dir)
 
     @app.get("/", response_class=HTMLResponse)
     def ui():
@@ -92,10 +283,24 @@ def create_app(runtime) -> FastAPI:
     def upscalers():
         """List available pixel upscaler names (short, no .safetensors suffix).
 
-        Pixel upscalers are a pixel-space / server concern and need no diffusion
+        Pixel upscalers are a pixel-domain / server concern and need no diffusion
         model, so this works even when no model is loaded.
         """
         return {"upscalers": runtime.pixel_upscalers.list()}
+
+    @app.get("/gallery")
+    def gallery_list():
+        """Return a list of saved gallery images with their metadata."""
+        if gallery is None or not gallery.active:
+            return []
+        return gallery.list_images()
+
+    @app.get("/gallery-images/{filename:path}")
+    def gallery_image(filename: str):
+        """Serve a specific gallery image."""
+        if gallery is None:
+            return JSONResponse(status_code=404, content="gallery not configured")
+        return gallery.serve(filename)
 
     @app.post("/text2image")
     def text2image(req: Text2ImageRequest):
@@ -111,6 +316,13 @@ def create_app(runtime) -> FastAPI:
         buf = io.BytesIO()
         image.save(buf, format="PNG", pnginfo=getattr(image, "_pnginfo", None))
         content = buf.getvalue()
+
+        if gallery is not None:
+            fname = gallery.save(image)
+            if fname:
+                logger.info("gallery: saved %s", fname)
+            else:
+                logger.warning("gallery: save returned None for image")
 
         if req.out == "json":
             return {"b64_json": base64.b64encode(content).decode("ascii")}

--- a/thenoise/cli.py
+++ b/thenoise/cli.py
@@ -53,6 +53,9 @@ def build_parser() -> argparse.ArgumentParser:
                        help="bind port (default: 8000)")
     serve.add_argument("--device", default="cuda",
                        help="inference device; ROCm aliases cuda -> hip (default: cuda)")
+    serve.add_argument("--gallery", default="", metavar="PATH",
+                       help="directory to save generated images and serve "
+                            "a persistent gallery from future starts")
 
     # generate
     gen = sub.add_parser("generate", help="run one generation and save a PNG")

--- a/thenoise/runtime.py
+++ b/thenoise/runtime.py
@@ -24,11 +24,15 @@ class Settings:
     ``upscaler_dir`` is server configuration (like host/port): pixel-domain
     upscaling is a pixel-space / postprocessing concern that needs no diffusion
     model, so its directory is NOT a model-load parameter.
+
+    ``gallery_dir`` is a server configuration: when set, generated images are
+    saved here and served in the gallery.
     """
     device: str = "cuda"      # ROCm torch aliases cuda -> hip
     host: str = "127.0.0.1"
     port: int = 8000
     upscaler_dir: str = ""     # directory of pixel-domain upscaler models
+    gallery_dir: str = ""     # directory for saving/serving generated images
 
 
 @dataclass

--- a/thenoise/ui/index.html
+++ b/thenoise/ui/index.html
@@ -38,6 +38,26 @@
   }
   .sidebar h1 { font-size: 1.05rem; font-weight: 650; letter-spacing: .01em; }
   .sidebar h1 .dot { color: var(--accent); }
+  /* gallery toggle */
+  .gallery-btn {
+    display: none;
+    background: var(--input);
+    color: var(--dim);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: .35rem .6rem;
+    font-size: .72rem;
+    font-weight: 600;
+    cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: .05em;
+    transition: border-color .12s, color .12s;
+    justify-content: center;
+  }
+  .gallery-btn:hover { color: var(--text); }
+  .gallery-btn.active { color: var(--accent); border-color: var(--accent); background: var(--accent-soft); }
+  .gallery-btn.visible { display: flex; }
+  .gallery-btn.visible { display: flex !important; }
   .field { display: flex; flex-direction: column; gap: .4rem; }
   .field > label { font-size: .78rem; color: var(--dim); font-weight: 600; text-transform: uppercase; letter-spacing: .05em; }
   .sidebar input, .sidebar textarea, .sidebar select {
@@ -155,6 +175,62 @@
   }
   .swap:hover { color: var(--accent); border-color: var(--accent); }
 
+  /* gallery grid */
+  .gallery-grid {
+    display: none;
+    flex-wrap: wrap;
+    gap: .75rem;
+    width: 100%;
+    padding: 1rem 0;
+  }
+  .gallery-grid.visible { display: flex; }
+  .gallery-grid .gallery-item {
+    width: 120px;
+    aspect-ratio: 1;
+    border-radius: 8px;
+    overflow: hidden;
+    border: 2px solid var(--border);
+    cursor: pointer;
+    background: var(--panel);
+    position: relative;
+  }
+  .gallery-grid .gallery-item:hover { border-color: var(--accent); }
+  .gallery-grid .gallery-item.selected { border-color: var(--accent); }
+  .gallery-grid .gallery-item img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+  .gallery-grid .gallery-item .seed-label {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, .6);
+    color: #ccc;
+    font-size: .58rem;
+    text-align: center;
+    padding: .1rem 0;
+    font-variant-numeric: tabular-nums;
+  }
+  .gallery-grid .gallery-item.loading img {
+    opacity: 0;
+  }
+  .gallery-grid .gallery-item.loading::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 6px;
+    background: var(--panel);
+    animation: pulse-bg 1.2s ease-in-out infinite;
+  }
+  @keyframes pulse-bg {
+    0%, 100% { background: var(--panel); }
+    50% { background: var(--panel-2); }
+  }
+  .main-title { display: flex; align-items: baseline; gap: .5rem; }
+
   /* ---------- main ---------- */
   .main {
     flex: 1; min-width: 0;
@@ -224,7 +300,11 @@
 <body>
 
 <aside class="sidebar">
-  <h1>The<span class="dot">Noise</span></h1>
+  <div class="main-title">
+    <h1>The<span class="dot">Noise</span></h1>
+  </div>
+
+  <div class="divider"></div>
 
   <div class="field">
     <label for="prompt">Prompt</label>
@@ -326,6 +406,8 @@
   </div>
 
   <button class="btn" id="generate">Generate</button>
+
+  <button class="gallery-btn" id="galleryBtn" disabled>Gallery</button>
 </aside>
 
 <main class="main">
@@ -347,7 +429,9 @@
     </div>
   </details>
 
-  <div class="history hidden" id="history">
+  <div class="gallery-grid" id="galleryGrid"></div>
+
+  <div class="history" id="history">
     <div class="history-head">History</div>
     <div class="history-items" id="history_items"></div>
   </div>
@@ -772,6 +856,97 @@ $('generate').addEventListener('click', async () => {
     btn.disabled = false;
   }
 });
+
+/* ---------- gallery mode ---------- */
+let activeTab = 'generate'; // 'generate' | 'gallery'
+let galleryItems = [];
+
+function showGallery(show) {
+  activeTab = show ? 'gallery' : 'generate';
+  const isGallery = activeTab === 'gallery';
+  $('galleryBtn').classList.toggle('active', isGallery);
+  $('galleryGrid').classList.toggle('visible', isGallery);
+  $('history').classList.toggle('hidden', isGallery);
+  $('timer').style.display = isGallery ? 'none' : '';
+  $('info').style.display = isGallery ? 'none' : '';
+  if (!isGallery) {
+    currentUrl = null;
+    currentMeta = null;
+  }
+  if (isGallery) {
+    loadGallery();
+  }
+}
+
+function renderGallery() {
+  const grid = $('galleryGrid');
+  grid.innerHTML = '';
+  galleryItems.forEach(item => {
+    const div = document.createElement('div');
+    div.className = 'gallery-item' + (item.url === currentUrl ? ' selected' : '');
+    const img = document.createElement('img');
+    img.src = item.url;
+    img.alt = 'gallery image';
+    div.appendChild(img);
+    const seed = document.createElement('span');
+    seed.className = 'seed-label';
+    seed.textContent = item.meta && item.meta.seed != null ? item.meta.seed : '';
+    div.appendChild(seed);
+    div.addEventListener('click', () => selectGalleryItem(item));
+    grid.appendChild(div);
+  });
+}
+
+function selectGalleryItem(item) {
+  currentUrl = item.url;
+  currentMeta = item.meta;
+  const img = $('image');
+  img.src = item.url;
+  img.style.display = 'block';
+  $('placeholder').style.display = 'none';
+
+  if (item.meta) {
+    renderInfo(item.meta);
+    applySettings(item.meta);
+  }
+
+  $('download').disabled = false;
+  $('galleryGrid').querySelectorAll('.gallery-item').forEach((el, i) => {
+    el.classList.toggle('selected', galleryItems[i] === item);
+  });
+}
+
+function loadGallery() {
+  fetch('/gallery').then(r => r.json()).then(items => {
+    if (items && items.length > 0) {
+      galleryItems = items;
+      renderGallery();
+    }
+  }).catch(() => {});
+}
+
+// Initial gallery load
+fetch('/gallery').then(r => r.json()).then(items => {
+  if (items && items.length > 0) {
+    const btn = $('galleryBtn');
+    if (btn) {
+      btn.classList.add('visible');
+      btn.disabled = false;
+    }
+    galleryItems = items;
+    renderGallery();
+    if (activeTab !== 'gallery') {
+      showGallery(true);
+    }
+  }
+}).catch(() => {});
+
+// Single click handler
+$('galleryBtn').addEventListener('click', () => {
+  showGallery(activeTab !== 'gallery');
+});
+
+
 </script>
 </body>
 </html>


### PR DESCRIPTION
run generate with `--gallery <dir>` to automatically save generated images in the specified directory. This also enables loading of the saved images at startup. Because generation parameters - prompt, sampling, loras, etc - are saved in the PNG metadata, it can also be reloaded into the UI.

This also creates a gallery API to fetch the list of images in the gallery directory.

If gallery is not enabled, images are not saved to or loaded from disk, and no gallery element is present in the UI.

Fixes #12

Example: `./thenoise.sh serve   --dit ./models/anima/split_files/diffusion_models/anima-turbo-v1.0.safetensors   --vae ./models/anima/split_files/vae/qwen_image_vae.safetensors   --text-encoder ./models/anima/split_files/text_encoders/qwen_3_06b_base.safetensors   --host 127.0.0.1 --port 19000 --gallery images`

<img width="1914" height="1049" alt="image" src="https://github.com/user-attachments/assets/3c52b21c-abf4-4662-9169-c43f3fe718f1" />
