### PR TITLE
Add INT8 ConvRot quantization support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,18 +4,10 @@ Guidance for AI coding agents working in this repository.
 
 ## Project overview
 
-`thenoise` is a focused diffusion inference engine for ROCm (Strix Halo /
-gfx1151, RDNA 3.5, native BF16/FP16, 128GB unified RAM). It loads **one model at
-a time** and exposes a small, explicit surface.
-
-- **Layout**:
-  - `thenoise/` — server package: `__main__.py` + `cli.py` (CLI entrypoints),
-    `api.py` (FastAPI `/text2image`), `runtime.py` (single-model runtime),
-    `models/` (adapters + catalog + detect), `dit/` (per-model compute),
-    `vae/` (shared Qwen-Image VAE), `utils/` (safetensors, lora, attention, device).
-  - `scripts/` — model download helpers.
-  - `tests/` — CLI + runtime + detection tests (no torch needed).
-- Invocation: `python -m thenoise serve ...` and `python -m thenoise generate ...`.
+`thenoise` is a focused diffusion inference engine for ROCm. It loads **one model at
+a time** and exposes a small, explicit surface. The main deployment target is
+Strix Halo / gfx1151, RDNA 3.5, native BF16/FP16, 128GB unified RAM. Other tested
+targets are gfx1150 and gfx1152.
 
 ## Critical constraints
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Download:
 
 This fetches the bf16 Turbo DiT (~26 GB), the VAE (~0.25 GB), and the Qwen3-VL
 text encoder (~8.9 GB). Add `--include-raw` for the non-turbo DiT (another
-~26 GB).
+~26 GB), and `--int8-convrot` to fetch the int8-convrot DiT(s) instead of bf16.
 
 ### Anima
 
@@ -214,7 +214,8 @@ same value in your `--dit` path:
 ```
 
 Available variants include `turbo-v1.0` (fewest steps), `aesthetic-v1.1`, and
-`base-v1.0`.
+`base-v1.0`. Add `--int8-convrot` to fetch the int8-convrot DiT (from
+`Bedovyy/Anima-INT8`) instead of the bf16 one.
 
 ### Z-Image-Turbo
 
@@ -223,7 +224,8 @@ Available variants include `turbo-v1.0` (fewest steps), `aesthetic-v1.1`, and
 ```
 
 This fetches the single-file bf16 Turbo DiT (~12 GB), the Flux VAE (`ae.safetensors`),
-and the Qwen3-4B text encoder (`qwen_3_4b.safetensors`, ~8 GB).
+and the Qwen3-4B text encoder (`qwen_3_4b.safetensors`, ~8 GB). Add
+`--int8-convrot` to fetch the int8-convrot DiT instead.
 
 ```bash
 ./thenoise.sh generate \
@@ -244,6 +246,11 @@ This fetches the single-file bf16 DiT, the Flux.2 VAE (`flux2-vae.safetensors`),
 and the Qwen3 text encoder (a single file from Comfy-Org). Pick `--variant` from
 `4b` / `4b-base` / `9b` / `9b-base`. The 9B DiTs come from the official
 black-forest-labs repos (they are not published as single files elsewhere).
+
+Add `--int8-convrot` to fetch the int8-convrot DiT instead. The 4B DiT comes from
+`wraps/FLUX.2-klein-4B-INT8-ConvRot-ComfyUI`; the 9B DiT is only published on
+Civitai and is downloaded directly from there (if Civitai requires login, the
+script prints the model page link). Base variants have no int8-convrot release.
 
 The DiT size (4B vs 9B) is auto-detected from the checkpoint; the matching Qwen3
 text encoder is selected automatically. The distilled variants (default) run 4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TheNoise
 
-A text-to-image diffusion inference engine. Tested on Strix Halo and Strix Point.
+A text-to-image diffusion inference engine. Tested on Strix Halo, Strix Point and Krackan Point.
 
 Loads one model at a time and generates images from text prompts. Available as a CLI tool, an HTTP API (with a simple web UI).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "einops==0.7.0",
     "accelerate==1.6.0",
     "pillow>=11.3.0",
+    "comfy-kitchen",
     "numpy",
     "tqdm",
 ]

--- a/scripts/download_anima.py
+++ b/scripts/download_anima.py
@@ -10,9 +10,14 @@ Source: https://huggingface.co/circlestone-labs/Anima
 The Qwen3 / T5 tokenizer configs are packaged under ``thenoise/dit/anima/configs/``, so
 they are not downloaded.
 
+Pass ``--int8-convrot`` to fetch the int8-convrot DiT instead. The DiT lives in
+``Bedovyy/Anima-INT8`` (``anima-<variant>-int8convrot.safetensors``); the text
+encoder and VAE still come from ``circlestone-labs/Anima``.
+
 Usage:
     python scripts/download_anima.py --out ./models/anima
     python scripts/download_anima.py --out ./models/anima --variant aesthetic-v1.1
+    python scripts/download_anima.py --out ./models/anima --int8-convrot
 """
 from __future__ import annotations
 
@@ -22,6 +27,7 @@ from pathlib import Path
 from huggingface_hub import hf_hub_download
 
 REPO = "circlestone-labs/Anima"
+INT8_REPO = "Bedovyy/Anima-INT8"
 DEFAULT_VARIANT = "turbo-v1.0"
 
 
@@ -32,18 +38,27 @@ def main() -> None:
         "--variant", default=DEFAULT_VARIANT,
         help=f"DiT variant to download (default: {DEFAULT_VARIANT})",
     )
+    ap.add_argument(
+        "--int8-convrot", action="store_true",
+        help="download the int8-convrot DiT instead of bf16",
+    )
     args = ap.parse_args()
 
     out = Path(args.out)
     out.mkdir(parents=True, exist_ok=True)
 
+    if args.int8_convrot:
+        dit = (INT8_REPO, f"anima-{args.variant}-int8convrot.safetensors")
+    else:
+        dit = (REPO, f"split_files/diffusion_models/anima-{args.variant}.safetensors")
+
     artifacts = [
-        ("dit", f"split_files/diffusion_models/anima-{args.variant}.safetensors"),
-        ("text_encoder", "split_files/text_encoders/qwen_3_06b_base.safetensors"),
-        ("vae", "split_files/vae/qwen_image_vae.safetensors"),
+        ("dit", *dit),
+        ("text_encoder", REPO, "split_files/text_encoders/qwen_3_06b_base.safetensors"),
+        ("vae", REPO, "split_files/vae/qwen_image_vae.safetensors"),
     ]
-    for name, path in artifacts:
-        dest = hf_hub_download(REPO, path, local_dir=str(out))
+    for name, repo, path in artifacts:
+        dest = hf_hub_download(repo, path, local_dir=str(out))
         print(f"{name:14s} -> {dest}")
 
 

--- a/scripts/download_klein.py
+++ b/scripts/download_klein.py
@@ -1,14 +1,7 @@
 """Download the Flux.2 (Flux Klein) model artifacts into a local directory.
 
 The DiT and text encoder use single-file bf16 checkpoints from Comfy-Org where
-available (the project's preferred format). The 9B DiT (and its base variant) are
-only published by black-forest-labs, so those come from the official repos.
-
-The Qwen3 tokenizer config files are vendored under
-``thenoise/dit/zimage/configs/tokenizer/`` (reused by Flux Klein), so no tokenizer
-is downloaded. The Flux2 latent upscaler is already committed under
-``thenoise/upscale/weights/upscaler_flux2.safetensors`` (bf16), so it is not
-downloaded either.
+available (the project's preferred format).
 
   Variant     DiT                                    Text encoder
   ---------   ------------------------------------   --------------
@@ -44,8 +37,8 @@ VAE = (COMFY_4B, "split_files/vae/flux2-vae.safetensors")
 DITS = {
     "4b": (COMFY_4B, "split_files/diffusion_models/flux-2-klein-4b.safetensors"),
     "4b-base": (COMFY_4B, "split_files/diffusion_models/flux-2-klein-base-4b.safetensors"),
-    "9b": ("black-forest-labs/FLUX.2-klein-9B", "flux-2-klein-9b.safetensors"),
-    "9b-base": ("black-forest-labs/FLUX.2-klein-base-9B", "flux-2-klein-base-9b.safetensors"),
+    "9b": ("unsloth/FLUX.2-klein-9B", "flux-2-klein-9b.safetensors"),
+    "9b-base": ("unsloth/FLUX.2-klein-base-9B", "flux-2-klein-base-9b.safetensors"),
 }
 
 #: variant -> DiT size key used to pick the text encoder.

--- a/scripts/download_klein.py
+++ b/scripts/download_klein.py
@@ -10,8 +10,14 @@ available (the project's preferred format).
   9b          9b (distilled)                         Qwen3-8B
   9b-base     base (CFG, 50 steps)                   Qwen3-8B
 
+Pass ``--int8-convrot`` to fetch the int8-convrot DiT instead of bf16. The 4B
+DiT comes from ``wraps/FLUX.2-klein-4B-INT8-ConvRot-ComfyUI``; the 9B DiT is
+only published on Civitai and is downloaded from there directly. Base variants
+have no int8-convrot release and are rejected.
+
 Usage:
     python scripts/download_klein.py --out ./models/klein --variant 4b
+    python scripts/download_klein.py --out ./models/klein --variant 4b --int8-convrot
 """
 from __future__ import annotations
 
@@ -44,6 +50,28 @@ DITS = {
 #: variant -> DiT size key used to pick the text encoder.
 _DIT_SIZE = {"4b": "4b", "4b-base": "4b", "9b": "9b", "9b-base": "9b"}
 
+#: int8-convrot 4B DiT (HuggingFace).
+INT8_4B = ("wraps/FLUX.2-klein-4B-INT8-ConvRot-ComfyUI", "flux-2-klein-4b-int8-convrot.safetensors")
+
+#: int8-convrot 9B DiT (Civitai direct download URL + human link).
+INT8_9B_URL = "https://civitai.com/api/download/models/3079984?fileId=2959248"
+INT8_9B_LINK = "https://civitai.com/models/2738890/flux-2-klein-9b-int8"
+
+
+def download_civitai(url: str, dest: Path) -> None:
+    """Download a model from Civitai, printing the web link if login is required."""
+    import urllib.error
+    import urllib.request
+
+    try:
+        urllib.request.urlretrieve(url, dest)
+    except (urllib.error.HTTPError, urllib.error.URLError) as e:
+        if getattr(e, "code", 0) in (401, 403):
+            print("Civitai requires login to download this model.")
+            print(f"Open {INT8_9B_LINK} in your browser and download the file manually.")
+            raise SystemExit(1) from e
+        raise
+
 
 def main() -> None:
     ap = argparse.ArgumentParser(description="Download Flux.2 (Flux Klein) model artifacts")
@@ -54,6 +82,10 @@ def main() -> None:
         default="4b",
         help="model variant: 4b / 4b-base (distilled / base 4B), 9b / 9b-base (distilled / base 9B)",
     )
+    ap.add_argument(
+        "--int8-convrot", action="store_true",
+        help="download the int8-convrot DiT instead of bf16",
+    )
     args = ap.parse_args()
 
     out = Path(args.out)
@@ -62,16 +94,29 @@ def main() -> None:
     size = _DIT_SIZE[args.variant]
     te_repo, te_path = TEXT_ENCODERS[size]
     vae_repo, vae_path = VAE
-    dit_repo, dit_path = DITS[args.variant]
 
-    jobs = [
-        ("dit", dit_repo, dit_path),
-        ("vae", vae_repo, vae_path),
-        ("text_encoder", te_repo, te_path),
-    ]
+    if args.int8_convrot:
+        if args.variant in ("4b-base", "9b-base"):
+            ap.error(f"--int8-convrot is not available for variant {args.variant}")
+
+        if args.variant == "4b":
+            dit_repo, dit_path = INT8_4B
+            jobs = [("dit", dit_repo, dit_path)]
+        else:  # 9b
+            jobs = []
+            dest = out / "flux-2-klein-9b-int8-convrot.safetensors"
+            print("Downloading 9B int8-convrot DiT from Civitai")
+            download_civitai(INT8_9B_URL, dest)
+            print(f"{'dit':13s} -> {dest}")
+    else:
+        dit_repo, dit_path = DITS[args.variant]
+        jobs = [("dit", dit_repo, dit_path)]
+
+    jobs += [("vae", vae_repo, vae_path), ("text_encoder", te_repo, te_path)]
     for name, repo, path in jobs:
         dest = hf_hub_download(repo, path, local_dir=str(out))
         print(f"{name:13s} -> {dest}")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/download_krea2.py
+++ b/scripts/download_krea2.py
@@ -1,12 +1,18 @@
 """Download the Krea 2 model artifacts into a local directory.
 
 Uses huggingface_hub. All files come from `Comfy-Org/Krea-2`, which needs no
-authentication. We only fetch the bf16 variants:
+authentication. By default we fetch the bf16 variants:
 
   DiT (Turbo)  diffusion_models/krea2_turbo_bf16.safetensors
   DiT (RAW)    diffusion_models/krea2_raw_bf16.safetensors   (--include-raw)
   VAE          vae/qwen_image_vae.safetensors
   Text encoder text_encoders/qwen3vl_4b_bf16.safetensors
+
+Pass `--int8-convrot` to swap the DiT(s) for the int8-convrot checkpoints
+instead (same repo):
+
+  DiT (Turbo)  diffusion_models/krea2_turbo_int8_convrot.safetensors
+  DiT (RAW)    diffusion_models/krea2_raw_int8_convrot.safetensors
 
 The Qwen3-VL tokenizer is fetched automatically (by repo id) at first
 text-encoder load.
@@ -14,6 +20,7 @@ text-encoder load.
 Usage:
     python scripts/download_krea2.py --out ./models/krea2
     python scripts/download_krea2.py --out ./models/krea2 --include-raw
+    python scripts/download_krea2.py --out ./models/krea2 --int8-convrot
 """
 from __future__ import annotations
 
@@ -31,17 +38,29 @@ ARTIFACTS = {
     "dit_raw": "diffusion_models/krea2_raw_bf16.safetensors",
 }
 
+INT8_ARTIFACTS = {
+    "dit_turbo": "diffusion_models/krea2_turbo_int8_convrot.safetensors",
+    "vae": "vae/qwen_image_vae.safetensors",
+    "text_encoder": "text_encoders/qwen3vl_4b_bf16.safetensors",
+    "dit_raw": "diffusion_models/krea2_raw_int8_convrot.safetensors",
+}
+
 
 def main() -> None:
-    ap = argparse.ArgumentParser(description="Download Krea 2 model artifacts (bf16)")
+    ap = argparse.ArgumentParser(description="Download Krea 2 model artifacts")
     ap.add_argument("--out", default="./models/krea2", help="output directory")
     ap.add_argument("--include-raw", action="store_true", help="also download the RAW DiT")
+    ap.add_argument(
+        "--int8-convrot", action="store_true",
+        help="download int8-convrot DiTs instead of bf16",
+    )
     args = ap.parse_args()
 
     out = Path(args.out)
     out.mkdir(parents=True, exist_ok=True)
 
-    items = list(ARTIFACTS.items())
+    artifacts = INT8_ARTIFACTS if args.int8_convrot else ARTIFACTS
+    items = list(artifacts.items())
     if not args.include_raw:
         items = [i for i in items if i[0] != "dit_raw"]
 

--- a/scripts/download_zimage.py
+++ b/scripts/download_zimage.py
@@ -1,25 +1,29 @@
 """Download the Z-Image-Turbo model artifacts into a local directory.
 
-Everything comes from ``Comfy-Org/z_image_turbo`` (single-file bf16, no auth): the
-DiT, the Flux VAE, and the Qwen3-4B text encoder are each one safetensors file. The
-tokenizer config files are vendored under ``thenoise/dit/zimage/configs/tokenizer/``
-(they carry the Qwen chat template used by the caption encoder), so no tokenizer is
-downloaded; the model's vendored config means no ``config.json`` is needed next to
-the text encoder.
+Everything comes from ``Comfy-Org/z_image_turbo`` (single-file, no auth): the
+DiT, the Flux VAE, and the Qwen3-4B text encoder are each one safetensors file.
+By default the bf16 DiT is fetched; pass ``--int8-convrot`` to fetch the
+int8-convrot DiT instead (same repo). The tokenizer config files are vendored
+under ``thenoise/dit/zimage/configs/tokenizer/`` (they carry the Qwen chat
+template used by the caption encoder), so no tokenizer is downloaded; the
+model's vendored config means no ``config.json`` is needed next to the text
+encoder.
 
 The Flux latent upscaler for the Z-Image upscale path is fetched from
 ``LoganBooker/SesquiLSR`` and converted fp32 -> bf16 into the package's committed
 ``thenoise/upscale/weights/`` directory (the format registry expects
 ``upscaler_flux.safetensors`` there).
 
-  DiT           split_files/diffusion_models/z_image_turbo_bf16.safetensors
-  VAE           split_files/vae/ae.safetensors                             (Flux VAE)
-  Text encoder  split_files/text_encoders/qwen_3_4b.safetensors           (Qwen3-4B)
-  Tokenizer     vendored in thenoise/dit/zimage/configs/tokenizer/       (not downloaded)
-  Flux upscaler thenoise/upscale/weights/upscaler_flux.safetensors        (bf16)
+  DiT (bf16)     split_files/diffusion_models/z_image_turbo_bf16.safetensors
+  DiT (int8)     split_files/diffusion_models/z_image_turbo_int8_convrot.safetensors  (--int8-convrot)
+  VAE            split_files/vae/ae.safetensors                             (Flux VAE)
+  Text encoder   split_files/text_encoders/qwen_3_4b.safetensors           (Qwen3-4B)
+  Tokenizer      vendored in thenoise/dit/zimage/configs/tokenizer/       (not downloaded)
+  Flux upscaler  thenoise/upscale/weights/upscaler_flux.safetensors        (bf16)
 
 Usage:
     python scripts/download_zimage.py --out ./models/zimage
+    python scripts/download_zimage.py --out ./models/zimage --int8-convrot
 """
 from __future__ import annotations
 
@@ -43,6 +47,11 @@ SINGLE_FILES = [
     ("vae", COMFY_REPO, "split_files/vae/ae.safetensors"),
     ("text_encoder", COMFY_REPO, "split_files/text_encoders/qwen_3_4b.safetensors"),
 ]
+
+#: The int8-convrot DiT lives in the same repo.
+INT8_DIT = (
+    "dit", COMFY_REPO, "split_files/diffusion_models/z_image_turbo_int8_convrot.safetensors"
+)
 
 
 def download_flux_upscaler() -> Path:
@@ -78,12 +87,20 @@ def download_flux_upscaler() -> Path:
 def main() -> None:
     ap = argparse.ArgumentParser(description="Download Z-Image-Turbo model artifacts")
     ap.add_argument("--out", default="./models/zimage", help="output directory")
+    ap.add_argument(
+        "--int8-convrot", action="store_true",
+        help="download the int8-convrot DiT instead of bf16",
+    )
     args = ap.parse_args()
 
     out = Path(args.out)
     out.mkdir(parents=True, exist_ok=True)
 
-    for name, repo, path in SINGLE_FILES:
+    files = SINGLE_FILES
+    if args.int8_convrot:
+        files = [INT8_DIT] + [f for f in SINGLE_FILES if f[0] != "dit"]
+
+    for name, repo, path in files:
         dest = hf_hub_download(repo, path, local_dir=str(out))
         print(f"{name:14s} -> {dest}")
 

--- a/tests/test_int8.py
+++ b/tests/test_int8.py
@@ -51,6 +51,85 @@ def test_quantized_linear_load_int8_frees_bf16_weight():
     assert layer.weight is None  # bf16 weight dropped -> memory savings
 
 
+def test_quantized_linear_int8_lora_residual():
+    layer = QuantizedLinear(256, 512)
+    layer.load_int8(
+        torch.randint(-127, 127, (512, 256), dtype=torch.int8),
+        torch.rand(512, 1),
+    )
+    x = torch.randn(4, 256, dtype=torch.bfloat16)
+    base = layer(x)  # without LoRA
+
+    # LoRA factors: down [r, in], up [out, r]
+    down = torch.randn(8, 256, dtype=torch.bfloat16)
+    up = torch.randn(512, 8, dtype=torch.bfloat16)
+    layer.apply_lora(down, up, alpha=8.0, multiplier=0.5, calc_device=torch.device("cpu"))
+    assert layer._lora is True
+
+    out = layer(x)
+    # expected residual: x @ down^T @ up^T * (alpha/r * multiplier)
+    expected = base + x @ (down * (8.0 / 8 * 0.5)).t() @ up.t()
+    assert torch.allclose(out.float(), expected.float(), rtol=1e-2, atol=1e-2)
+
+    layer.clear_lora()
+    assert layer._lora is False
+    assert torch.allclose(layer(x).float(), base.float(), rtol=1e-2, atol=1e-2)
+
+
+class _TinyInt8Model(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.q = QuantizedLinear(256, 512)
+        self.q.load_int8(
+            torch.randint(-127, 127, (512, 256), dtype=torch.int8),
+            torch.rand(512, 1),
+        )
+        self.plain = nn.Linear(256, 512)
+
+
+def _int8_lora_sd():
+    return {
+        "q.lora_down.weight": torch.randn(8, 256, dtype=torch.bfloat16),
+        "q.lora_up.weight": torch.randn(512, 8, dtype=torch.bfloat16),
+        "q.alpha": torch.tensor(8.0),
+    }
+
+
+def test_apply_lora_to_model_int8_residual():
+    from thenoise.utils.lora import apply_lora_to_model, undo_lora_on_model
+
+    model = _TinyInt8Model()
+    result = apply_lora_to_model(
+        model, [_int8_lora_sd()], [1.0], torch.device("cpu")
+    )
+    assert model.q._lora is True
+    assert result["int8_affected"] == ("q",)
+
+    undo_lora_on_model(model, result, torch.device("cpu"))
+    assert model.q._lora is False
+
+
+def test_apply_lora_to_model_mixed_int8_and_bf16():
+    from thenoise.utils.lora import apply_lora_to_model
+
+    model = _TinyInt8Model()
+    # LoRA targeting both the int8 q layer and the bf16 plain layer
+    sd = {
+        "q.lora_down.weight": torch.randn(8, 256, dtype=torch.bfloat16),
+        "q.lora_up.weight": torch.randn(512, 8, dtype=torch.bfloat16),
+        "q.alpha": torch.tensor(8.0),
+        "plain.lora_down.weight": torch.randn(8, 256, dtype=torch.bfloat16),
+        "plain.lora_up.weight": torch.randn(512, 8, dtype=torch.bfloat16),
+        "plain.alpha": torch.tensor(8.0),
+    }
+    result = apply_lora_to_model(model, [sd], [1.0], torch.device("cpu"))
+    assert model.q._lora is True
+    assert model.plain.weight is not None  # bf16 layer mutated normally
+    assert "plain.weight" in result["affected_keys"]
+    assert result["int8_affected"] == ("q",)
+
+
+
 # --------------------------------------------------------------------------- is_int8_checkpoint
 
 

--- a/tests/test_int8.py
+++ b/tests/test_int8.py
@@ -1,0 +1,143 @@
+"""INT8+ConvRot support tests.
+
+These cover the shared ``QuantizedLinear`` module and the generic INT8 loading
+helpers. They run on CPU (comfy_kitchen's eager backend) and need no GPU or real
+checkpoints.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+import torch.nn as nn
+
+from thenoise.dit.quantized import QuantizedLinear
+from thenoise.utils.int8 import is_int8_checkpoint, load_int8_state_dict
+
+# --------------------------------------------------------------------------- QuantizedLinear
+
+
+def test_quantized_linear_bf16_forward():
+    layer = QuantizedLinear(256, 512, bias=False)
+    torch.nn.init.ones_(layer.weight)
+    x = torch.randn(4, 256, dtype=torch.bfloat16)
+    out = layer(x)
+    assert out.shape == (4, 512)
+    assert out.dtype == torch.bfloat16
+    assert not layer._int8
+
+
+def test_quantized_linear_int8_forward():
+    layer = QuantizedLinear(256, 512, bias=False)
+    qweight = torch.randint(-127, 127, (512, 256), dtype=torch.int8)
+    scale = torch.rand(512, 1, dtype=torch.float32)
+    layer.load_int8(qweight, scale)
+    assert layer._int8
+    assert layer.weight is None
+    assert layer.qweight.dtype == torch.int8
+    assert layer.scale.dtype == torch.float32
+
+    x = torch.randn(4, 256, dtype=torch.bfloat16)
+    out = layer(x)
+    assert out.shape == (4, 512)
+    assert out.dtype == torch.bfloat16
+
+
+def test_quantized_linear_load_int8_frees_bf16_weight():
+    layer = QuantizedLinear(256, 512)
+    assert layer.weight is not None
+    layer.load_int8(torch.zeros(512, 256, dtype=torch.int8), torch.zeros(512, 1))
+    assert layer.weight is None  # bf16 weight dropped -> memory savings
+
+
+# --------------------------------------------------------------------------- is_int8_checkpoint
+
+
+def _write(path, tensors):
+    from safetensors.torch import save_file
+    save_file(tensors, str(path))
+
+
+def test_is_int8_checkpoint_true(tmp_path):
+    p = tmp_path / "int8.safetensors"
+    _write(p, {
+        "model.diffusion_model.blocks.0.cross_attn.k_proj.weight": torch.zeros(16, 8, dtype=torch.int8),
+        "model.diffusion_model.blocks.0.cross_attn.k_proj.weight_scale": torch.zeros(16, 1, dtype=torch.float32),
+        "model.diffusion_model.blocks.0.cross_attn.k_proj.comfy_quant": torch.zeros(8, dtype=torch.uint8),
+    })
+    assert is_int8_checkpoint(str(p)) is True
+
+
+def test_is_int8_checkpoint_false_for_bf16(tmp_path):
+    p = tmp_path / "bf16.safetensors"
+    _write(p, {
+        "blocks.0.cross_attn.k_proj.weight": torch.zeros(16, 8, dtype=torch.bfloat16),
+    })
+    assert is_int8_checkpoint(str(p)) is False
+
+
+# --------------------------------------------------------------------------- load_int8_state_dict
+
+
+class _TinyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.q = QuantizedLinear(256, 512, bias=False)
+        self.plain = nn.Linear(256, 512, bias=True)
+
+
+def _tiny_state_dict():
+    return {
+        "q.weight": torch.randint(-127, 127, (512, 256), dtype=torch.int8),
+        "q.weight_scale": torch.rand(512, 1, dtype=torch.float32),
+        "q.comfy_quant": torch.zeros(8, dtype=torch.uint8),
+        "plain.weight": torch.randn(512, 256, dtype=torch.bfloat16),
+        "plain.bias": torch.randn(512, dtype=torch.bfloat16),
+    }
+
+
+def test_load_int8_state_dict_mixed():
+    model = _TinyModel()
+    load_int8_state_dict(model, _tiny_state_dict())
+
+    # quantized layer switched to INT8
+    assert model.q._int8 is True
+    assert model.q.weight is None
+    assert model.q.qweight.dtype == torch.int8
+    assert model.q.scale.dtype == torch.float32
+
+    # bf16 layer assigned normally
+    assert model.plain.weight.dtype == torch.bfloat16
+    assert model.plain.bias.dtype == torch.bfloat16
+
+    # forward runs end-to-end (bf16 in -> bf16 out)
+    x = torch.randn(4, 256, dtype=torch.bfloat16)
+    assert model.q(x).shape == (4, 512)
+    assert model.q(x).dtype == torch.bfloat16
+
+
+def test_load_int8_state_dict_missing_scale_raises():
+    sd = _tiny_state_dict()
+    del sd["q.weight_scale"]
+    with pytest.raises(RuntimeError, match="missing its .weight_scale"):
+        load_int8_state_dict(_TinyModel(), sd)
+
+
+def test_load_int8_state_dict_orphan_scale_raises():
+    sd = _tiny_state_dict()
+    sd["plain.weight_scale"] = torch.zeros(512, 1, dtype=torch.float32)
+    with pytest.raises(RuntimeError, match="orphan"):
+        load_int8_state_dict(_TinyModel(), sd)
+
+
+# --------------------------------------------------------------------------- real checkpoint (optional)
+
+@pytest.mark.skipif(
+    not os.path.exists("models/anima/split_files/diffusion_models/anima-turbo-v1.0-int8convrot.safetensors"),
+    reason="real INT8 Anima checkpoint not present",
+)
+def test_real_int8_checkpoint_is_detected():
+    from thenoise.models import resolve
+    assert resolve("models/anima/split_files/diffusion_models/anima-turbo-v1.0-int8convrot.safetensors") is not None
+    assert is_int8_checkpoint("models/anima/split_files/diffusion_models/anima-turbo-v1.0-int8convrot.safetensors") is True

--- a/tests/test_int8.py
+++ b/tests/test_int8.py
@@ -211,11 +211,11 @@ def test_load_int8_state_dict_orphan_scale_raises():
         load_int8_state_dict(_TinyModel(), sd)
 
 
-# --------------------------------------------------------------------------- load_int8_if_present
+# --------------------------------------------------------------------------- load_dit (central quant-aware loader)
 
 
-def test_load_int8_if_present_true(tmp_path):
-    from thenoise.utils.int8 import load_int8_if_present
+def test_load_dit_int8(tmp_path):
+    from thenoise.utils.loader import load_dit
 
     p = tmp_path / "int8.safetensors"
     _write(p, {
@@ -226,23 +226,42 @@ def test_load_int8_if_present_true(tmp_path):
         "model.diffusion_model.plain.bias": torch.randn(512, dtype=torch.bfloat16),
     })
     model = _TinyModel()
-    assert load_int8_if_present(model, str(p), device="cpu", dtype=torch.bfloat16) is True
+    out = load_dit(model, str(p), device="cpu", dtype=torch.bfloat16)
+    assert out is model
     assert model.q._int8 is True
     assert model.q.qweight.dtype == torch.int8
     assert model.plain.weight.dtype == torch.bfloat16
 
 
-def test_load_int8_if_present_false_for_bf16(tmp_path):
-    from thenoise.utils.int8 import load_int8_if_present
+def test_load_dit_bf16(tmp_path):
+    from thenoise.utils.loader import load_dit
 
     p = tmp_path / "bf16.safetensors"
-    _write(p, {
-        "plain.weight": torch.randn(512, 256, dtype=torch.bfloat16),
-        "plain.bias": torch.randn(512, dtype=torch.bfloat16),
-    })
+    _write(p, _bf16_sd())
     model = _TinyModel()
-    assert load_int8_if_present(model, str(p), device="cpu", dtype=torch.bfloat16) is False
-    assert model.q._int8 is False  # untouched; caller loads bf16
+    load_dit(model, str(p), device="cpu", dtype=torch.bfloat16)
+    assert model.q._int8 is False
+    assert model.q.weight is not None  # bf16 layer assigned normally
+    assert model.q.weight.dtype == torch.bfloat16
+    assert model.plain.weight.dtype == torch.bfloat16
+
+
+def test_load_dit_int8_key_map(tmp_path):
+    from thenoise.utils.loader import load_dit
+
+    # ComfyUI's INT8 exporter stores norm ``scale`` params under ``weight``.
+    p = tmp_path / "int8.safetensors"
+    _write(p, {
+        "q.weight": torch.randint(-127, 127, (512, 256), dtype=torch.int8),
+        "q.weight_scale": torch.rand(512, 1),
+        "q.comfy_quant": torch.zeros(8, dtype=torch.uint8),
+        "norm.weight": torch.randn(512, dtype=torch.bfloat16),
+    })
+    model = _ScaleModel()
+    key_map = lambda k: k[: -len(".weight")] + ".scale" if k.endswith("norm.weight") else k
+    load_dit(model, str(p), device="cpu", dtype=torch.bfloat16, int8_key_map=key_map)
+    assert model.q._int8 is True
+    assert model.norm.scale.dtype == torch.bfloat16
 
 
 class _ScaleNorm(nn.Module):
@@ -258,23 +277,87 @@ class _ScaleModel(nn.Module):
         self.norm = _ScaleNorm(512)
 
 
-def test_load_int8_if_present_key_map(tmp_path):
-    from thenoise.utils.int8 import load_int8_if_present
+def test_load_dit_drop_keys_on_bf16(tmp_path):
+    from thenoise.utils.loader import load_dit
 
-    # ComfyUI's INT8 exporter stores norm ``scale`` params under ``weight``.
+    p = tmp_path / "bf16.safetensors"
+    sd = _bf16_sd()
+    sd["last.down.residual"] = torch.randn(16, dtype=torch.bfloat16)
+    sd["last.up.residual"] = torch.randn(16, dtype=torch.bfloat16)
+    _write(p, sd)
+    model = _TinyModel()
+    # Without drop_keys the strict load would fail on the unexpected keys.
+    load_dit(model, str(p), device="cpu", dtype=torch.bfloat16, drop_keys=("last.down", "last.up"))
+    assert model.q._int8 is False
+    assert model.plain.weight.dtype == torch.bfloat16
+
+
+def test_load_dit_drop_keys_on_int8(tmp_path):
+    from thenoise.utils.loader import load_dit
+
     p = tmp_path / "int8.safetensors"
-    _write(p, {
+    sd = {
         "q.weight": torch.randint(-127, 127, (512, 256), dtype=torch.int8),
         "q.weight_scale": torch.rand(512, 1),
         "q.comfy_quant": torch.zeros(8, dtype=torch.uint8),
-        "norm.weight": torch.randn(512, dtype=torch.bfloat16),
-    })
-    model = _ScaleModel()
-    key_map = lambda k: k[: -len(".weight")] + ".scale" if k.endswith("norm.weight") else k
-    assert load_int8_if_present(model, str(p), device="cpu", dtype=torch.bfloat16, key_map=key_map) is True
+        "plain.weight": torch.randn(512, 256, dtype=torch.bfloat16),
+        "plain.bias": torch.randn(512, dtype=torch.bfloat16),
+        "last.down.residual": torch.randn(16, dtype=torch.bfloat16),
+        "last.up.residual": torch.randn(16, dtype=torch.bfloat16),
+    }
+    _write(p, sd)
+    model = _TinyModel()
+    # drop_keys applies to the INT8 path too.
+    load_dit(model, str(p), device="cpu", dtype=torch.bfloat16, drop_keys=("last.down", "last.up"))
     assert model.q._int8 is True
-    assert model.norm.scale.dtype == torch.bfloat16
+    assert model.plain.weight.dtype == torch.bfloat16
 
+
+class _BufModel(nn.Module):
+    """Model with an internal buffer not saved in the checkpoint."""
+
+    def __init__(self):
+        super().__init__()
+        self.plain = nn.Linear(256, 512, bias=True)
+        self.register_buffer("rope_seq", torch.zeros(128))
+
+
+def test_load_dit_expected_missing(tmp_path):
+    from thenoise.utils.loader import load_dit
+
+    p = tmp_path / "bf16.safetensors"
+    _write(p, {
+        "plain.weight": torch.randn(512, 256, dtype=torch.bfloat16),
+        "plain.bias": torch.randn(512, dtype=torch.bfloat16),
+    })
+    model = _BufModel()
+    load_dit(
+        model, str(p), device="cpu", dtype=torch.bfloat16,
+        expected_missing=("rope_seq",),
+    )
+    assert model.plain.weight.dtype == torch.bfloat16
+    assert model.rope_seq.dtype == torch.float32  # buffer kept, not from checkpoint
+
+
+def test_load_dit_expected_missing_mismatch_raises(tmp_path):
+    from thenoise.utils.loader import load_dit
+
+    p = tmp_path / "bf16.safetensors"
+    _write(p, {"plain.weight": torch.randn(512, 256, dtype=torch.bfloat16)})  # plain.bias missing
+    model = _BufModel()
+    with pytest.raises(RuntimeError, match="missing"):
+        load_dit(
+            model, str(p), device="cpu", dtype=torch.bfloat16,
+            expected_missing=("rope_seq",),  # does not cover plain.bias
+        )
+
+
+def _bf16_sd():
+    return {
+        "q.weight": torch.randn(512, 256, dtype=torch.bfloat16),
+        "plain.weight": torch.randn(512, 256, dtype=torch.bfloat16),
+        "plain.bias": torch.randn(512, dtype=torch.bfloat16),
+    }
 
 
 # --------------------------------------------------------------------------- real checkpoint (optional)

--- a/tests/test_int8.py
+++ b/tests/test_int8.py
@@ -21,6 +21,7 @@ from thenoise.utils.int8 import is_int8_checkpoint, load_int8_state_dict
 def test_quantized_linear_bf16_forward():
     layer = QuantizedLinear(256, 512, bias=False)
     torch.nn.init.ones_(layer.weight)
+    layer = layer.to(torch.bfloat16)  # models are cast to bf16 by the adapter
     x = torch.randn(4, 256, dtype=torch.bfloat16)
     out = layer(x)
     assert out.shape == (4, 512)
@@ -208,6 +209,72 @@ def test_load_int8_state_dict_orphan_scale_raises():
     sd["plain.weight_scale"] = torch.zeros(512, 1, dtype=torch.float32)
     with pytest.raises(RuntimeError, match="orphan"):
         load_int8_state_dict(_TinyModel(), sd)
+
+
+# --------------------------------------------------------------------------- load_int8_if_present
+
+
+def test_load_int8_if_present_true(tmp_path):
+    from thenoise.utils.int8 import load_int8_if_present
+
+    p = tmp_path / "int8.safetensors"
+    _write(p, {
+        "model.diffusion_model.q.weight": torch.randint(-127, 127, (512, 256), dtype=torch.int8),
+        "model.diffusion_model.q.weight_scale": torch.rand(512, 1),
+        "model.diffusion_model.q.comfy_quant": torch.zeros(8, dtype=torch.uint8),
+        "model.diffusion_model.plain.weight": torch.randn(512, 256, dtype=torch.bfloat16),
+        "model.diffusion_model.plain.bias": torch.randn(512, dtype=torch.bfloat16),
+    })
+    model = _TinyModel()
+    assert load_int8_if_present(model, str(p), device="cpu", dtype=torch.bfloat16) is True
+    assert model.q._int8 is True
+    assert model.q.qweight.dtype == torch.int8
+    assert model.plain.weight.dtype == torch.bfloat16
+
+
+def test_load_int8_if_present_false_for_bf16(tmp_path):
+    from thenoise.utils.int8 import load_int8_if_present
+
+    p = tmp_path / "bf16.safetensors"
+    _write(p, {
+        "plain.weight": torch.randn(512, 256, dtype=torch.bfloat16),
+        "plain.bias": torch.randn(512, dtype=torch.bfloat16),
+    })
+    model = _TinyModel()
+    assert load_int8_if_present(model, str(p), device="cpu", dtype=torch.bfloat16) is False
+    assert model.q._int8 is False  # untouched; caller loads bf16
+
+
+class _ScaleNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.scale = nn.Parameter(torch.ones(dim))
+
+
+class _ScaleModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.q = QuantizedLinear(256, 512)
+        self.norm = _ScaleNorm(512)
+
+
+def test_load_int8_if_present_key_map(tmp_path):
+    from thenoise.utils.int8 import load_int8_if_present
+
+    # ComfyUI's INT8 exporter stores norm ``scale`` params under ``weight``.
+    p = tmp_path / "int8.safetensors"
+    _write(p, {
+        "q.weight": torch.randint(-127, 127, (512, 256), dtype=torch.int8),
+        "q.weight_scale": torch.rand(512, 1),
+        "q.comfy_quant": torch.zeros(8, dtype=torch.uint8),
+        "norm.weight": torch.randn(512, dtype=torch.bfloat16),
+    })
+    model = _ScaleModel()
+    key_map = lambda k: k[: -len(".weight")] + ".scale" if k.endswith("norm.weight") else k
+    assert load_int8_if_present(model, str(p), device="cpu", dtype=torch.bfloat16, key_map=key_map) is True
+    assert model.q._int8 is True
+    assert model.norm.scale.dtype == torch.bfloat16
+
 
 
 # --------------------------------------------------------------------------- real checkpoint (optional)

--- a/thenoise/dit/anima/models.py
+++ b/thenoise/dit/anima/models.py
@@ -11,6 +11,7 @@ from einops.layers.torch import Rearrange
 from torch import nn
 import torch.nn.functional as F
 
+from thenoise.dit.quantized import QuantizedLinear
 from thenoise.utils import attention
 
 from thenoise.utils.setup_logging import setup_logging
@@ -132,8 +133,8 @@ class GPT2FeedForward(nn.Module):
     def __init__(self, d_model: int, d_ff: int) -> None:
         super().__init__()
         self.activation = nn.GELU()
-        self.layer1 = nn.Linear(d_model, d_ff, bias=False)
-        self.layer2 = nn.Linear(d_ff, d_model, bias=False)
+        self.layer1 = QuantizedLinear(d_model, d_ff, bias=False)
+        self.layer2 = QuantizedLinear(d_ff, d_model, bias=False)
 
         self._layer_id = None
         self._dim = d_model
@@ -184,16 +185,16 @@ class Attention(nn.Module):
         self.query_dim = query_dim
         self.context_dim = context_dim
 
-        self.q_proj = nn.Linear(query_dim, inner_dim, bias=False)
+        self.q_proj = QuantizedLinear(query_dim, inner_dim, bias=False)
         self.q_norm = RMSNorm(self.head_dim, eps=1e-6)
 
-        self.k_proj = nn.Linear(context_dim, inner_dim, bias=False)
+        self.k_proj = QuantizedLinear(context_dim, inner_dim, bias=False)
         self.k_norm = RMSNorm(self.head_dim, eps=1e-6)
 
-        self.v_proj = nn.Linear(context_dim, inner_dim, bias=False)
+        self.v_proj = QuantizedLinear(context_dim, inner_dim, bias=False)
         self.v_norm = nn.Identity()
 
-        self.output_proj = nn.Linear(inner_dim, query_dim, bias=False)
+        self.output_proj = QuantizedLinear(inner_dim, query_dim, bias=False)
         self.output_dropout = nn.Dropout(dropout) if dropout > 1e-4 else nn.Identity()
 
         self._query_dim = query_dim

--- a/thenoise/dit/anima/utils.py
+++ b/thenoise/dit/anima/utils.py
@@ -7,7 +7,7 @@ from safetensors.torch import load_file
 from accelerate import init_empty_weights
 
 from thenoise.dit.anima import models as anima_models
-from thenoise.utils.int8 import is_int8_checkpoint, load_int8_state_dict
+from thenoise.utils.int8 import load_int8_if_present
 from thenoise.utils.safetensors import WRAP_PREFIXES, load_dit_safetensors
 from thenoise.utils.setup_logging import setup_logging
 
@@ -98,48 +98,44 @@ def load_anima_model(
         "extra_t_extrapolation_ratio": 1.0,
         "use_llm_adapter": True,
     }
-    is_int8 = is_int8_checkpoint(dit_path)
-    logger.info("Detected %s Anima DiT", "INT8+ConvRot" if is_int8 else "BF16")
-
     with init_empty_weights():
         model = anima_models.Anima(**dit_config)
         if dit_weight_dtype is not None:
             # Casts every init-time parameter to the target dtype. For INT8
             # checkpoints this is still correct: the int8 qweight/scale buffers
-            # are created later by load_int8_state_dict, so they are untouched.
+            # are created later by load_int8_if_present, so they are untouched.
             model.to(dit_weight_dtype)
 
     logger.info(f"Loading DiT model from {dit_path}, device={loading_device}")
 
-    # INT8 checkpoints keep their native dtypes (int8 weights, F32 scales, BF16
-    # everywhere else); BF16 checkpoints are cast to the requested dtype.
+    if load_int8_if_present(model, dit_path, device=loading_device, dtype=dit_weight_dtype):
+        return model
+
+    # BF16 path: cast to the requested dtype and load via load_state_dict.
     sd = load_dit_safetensors(
         dit_path,
         device=loading_device,
         disable_mmap=True,
-        dtype=None if is_int8 else dit_weight_dtype,
+        dtype=dit_weight_dtype,
     )
 
-    if is_int8:
-        load_int8_state_dict(model, sd)
-    else:
-        missing, unexpected = model.load_state_dict(sd, strict=False, assign=True)
-        if missing:
-            # Filter out expected missing buffers (initialized in __init__, not saved in checkpoint)
-            unexpected_missing = [
-                k
-                for k in missing
-                if not any(buf_name in k for buf_name in ("seq", "dim_spatial_range", "dim_temporal_range", "inv_freq"))
-            ]
-            if unexpected_missing:
-                # Raise error to avoid silent failures
-                raise RuntimeError(
-                    f"Missing keys in checkpoint: {unexpected_missing[:10]}{'...' if len(unexpected_missing) > 10 else ''}"
-                )
-            missing = {}  # all missing keys were expected
-        if unexpected:
+    missing, unexpected = model.load_state_dict(sd, strict=False, assign=True)
+    if missing:
+        # Filter out expected missing buffers (initialized in __init__, not saved in checkpoint)
+        unexpected_missing = [
+            k
+            for k in missing
+            if not any(buf_name in k for buf_name in ("seq", "dim_spatial_range", "dim_temporal_range", "inv_freq"))
+        ]
+        if unexpected_missing:
             # Raise error to avoid silent failures
-            raise RuntimeError(f"Unexpected keys in checkpoint: {unexpected[:5]}{'...' if len(unexpected) > 5 else ''}")
+            raise RuntimeError(
+                f"Missing keys in checkpoint: {unexpected_missing[:10]}{'...' if len(unexpected_missing) > 10 else ''}"
+            )
+        missing = {}  # all missing keys were expected
+    if unexpected:
+        # Raise error to avoid silent failures
+        raise RuntimeError(f"Unexpected keys in checkpoint: {unexpected[:5]}{'...' if len(unexpected) > 5 else ''}")
 
     # Move the whole model (including buffers not present in the checkpoint, e.g. the
     # RoPE position-embedding buffers seq/dim_spatial_range/dim_temporal_range) onto the
@@ -148,7 +144,7 @@ def load_anima_model(
     # would otherwise stay off-device and break rotary attention on the GPU.
     if loading_device.type != "cpu":
         model.to(loading_device)
-    logger.info("Loaded DiT model from %s (%s)", dit_path, "INT8+ConvRot" if is_int8 else "BF16")
+    logger.info("Loaded DiT model from %s", dit_path)
 
     return model
 

--- a/thenoise/dit/anima/utils.py
+++ b/thenoise/dit/anima/utils.py
@@ -7,6 +7,7 @@ from safetensors.torch import load_file
 from accelerate import init_empty_weights
 
 from thenoise.dit.anima import models as anima_models
+from thenoise.utils.int8 import is_int8_checkpoint, load_int8_state_dict
 from thenoise.utils.safetensors import WRAP_PREFIXES, load_dit_safetensors
 from thenoise.utils.setup_logging import setup_logging
 
@@ -97,37 +98,48 @@ def load_anima_model(
         "extra_t_extrapolation_ratio": 1.0,
         "use_llm_adapter": True,
     }
+    is_int8 = is_int8_checkpoint(dit_path)
+    logger.info("Detected %s Anima DiT", "INT8+ConvRot" if is_int8 else "BF16")
+
     with init_empty_weights():
         model = anima_models.Anima(**dit_config)
         if dit_weight_dtype is not None:
+            # Casts every init-time parameter to the target dtype. For INT8
+            # checkpoints this is still correct: the int8 qweight/scale buffers
+            # are created later by load_int8_state_dict, so they are untouched.
             model.to(dit_weight_dtype)
 
     logger.info(f"Loading DiT model from {dit_path}, device={loading_device}")
 
+    # INT8 checkpoints keep their native dtypes (int8 weights, F32 scales, BF16
+    # everywhere else); BF16 checkpoints are cast to the requested dtype.
     sd = load_dit_safetensors(
         dit_path,
         device=loading_device,
         disable_mmap=True,
-        dtype=dit_weight_dtype,
+        dtype=None if is_int8 else dit_weight_dtype,
     )
 
-    missing, unexpected = model.load_state_dict(sd, strict=False, assign=True)
-    if missing:
-        # Filter out expected missing buffers (initialized in __init__, not saved in checkpoint)
-        unexpected_missing = [
-            k
-            for k in missing
-            if not any(buf_name in k for buf_name in ("seq", "dim_spatial_range", "dim_temporal_range", "inv_freq"))
-        ]
-        if unexpected_missing:
+    if is_int8:
+        load_int8_state_dict(model, sd)
+    else:
+        missing, unexpected = model.load_state_dict(sd, strict=False, assign=True)
+        if missing:
+            # Filter out expected missing buffers (initialized in __init__, not saved in checkpoint)
+            unexpected_missing = [
+                k
+                for k in missing
+                if not any(buf_name in k for buf_name in ("seq", "dim_spatial_range", "dim_temporal_range", "inv_freq"))
+            ]
+            if unexpected_missing:
+                # Raise error to avoid silent failures
+                raise RuntimeError(
+                    f"Missing keys in checkpoint: {unexpected_missing[:10]}{'...' if len(unexpected_missing) > 10 else ''}"
+                )
+            missing = {}  # all missing keys were expected
+        if unexpected:
             # Raise error to avoid silent failures
-            raise RuntimeError(
-                f"Missing keys in checkpoint: {unexpected_missing[:10]}{'...' if len(unexpected_missing) > 10 else ''}"
-            )
-        missing = {}  # all missing keys were expected
-    if unexpected:
-        # Raise error to avoid silent failures
-        raise RuntimeError(f"Unexpected keys in checkpoint: {unexpected[:5]}{'...' if len(unexpected) > 5 else ''}")
+            raise RuntimeError(f"Unexpected keys in checkpoint: {unexpected[:5]}{'...' if len(unexpected) > 5 else ''}")
 
     # Move the whole model (including buffers not present in the checkpoint, e.g. the
     # RoPE position-embedding buffers seq/dim_spatial_range/dim_temporal_range) onto the
@@ -136,7 +148,7 @@ def load_anima_model(
     # would otherwise stay off-device and break rotary attention on the GPU.
     if loading_device.type != "cpu":
         model.to(loading_device)
-    logger.info(f"Loaded DiT model from {dit_path}, unexpected missing keys: {len(missing)}, unexpected keys: {len(unexpected)}")
+    logger.info("Loaded DiT model from %s (%s)", dit_path, "INT8+ConvRot" if is_int8 else "BF16")
 
     return model
 

--- a/thenoise/dit/anima/utils.py
+++ b/thenoise/dit/anima/utils.py
@@ -7,8 +7,8 @@ from safetensors.torch import load_file
 from accelerate import init_empty_weights
 
 from thenoise.dit.anima import models as anima_models
-from thenoise.utils.int8 import load_int8_if_present
-from thenoise.utils.safetensors import WRAP_PREFIXES, load_dit_safetensors
+from thenoise.utils.loader import load_dit
+from thenoise.utils.safetensors import WRAP_PREFIXES
 from thenoise.utils.setup_logging import setup_logging
 
 setup_logging()
@@ -100,50 +100,16 @@ def load_anima_model(
     }
     with init_empty_weights():
         model = anima_models.Anima(**dit_config)
-        if dit_weight_dtype is not None:
-            # Casts every init-time parameter to the target dtype. For INT8
-            # checkpoints this is still correct: the int8 qweight/scale buffers
-            # are created later by load_int8_if_present, so they are untouched.
-            model.to(dit_weight_dtype)
 
     logger.info(f"Loading DiT model from {dit_path}, device={loading_device}")
 
-    if load_int8_if_present(model, dit_path, device=loading_device, dtype=dit_weight_dtype):
-        return model
-
-    # BF16 path: cast to the requested dtype and load via load_state_dict.
-    sd = load_dit_safetensors(
+    load_dit(
+        model,
         dit_path,
         device=loading_device,
-        disable_mmap=True,
         dtype=dit_weight_dtype,
+        expected_missing=("seq", "dim_spatial_range", "dim_temporal_range", "inv_freq"),
     )
-
-    missing, unexpected = model.load_state_dict(sd, strict=False, assign=True)
-    if missing:
-        # Filter out expected missing buffers (initialized in __init__, not saved in checkpoint)
-        unexpected_missing = [
-            k
-            for k in missing
-            if not any(buf_name in k for buf_name in ("seq", "dim_spatial_range", "dim_temporal_range", "inv_freq"))
-        ]
-        if unexpected_missing:
-            # Raise error to avoid silent failures
-            raise RuntimeError(
-                f"Missing keys in checkpoint: {unexpected_missing[:10]}{'...' if len(unexpected_missing) > 10 else ''}"
-            )
-        missing = {}  # all missing keys were expected
-    if unexpected:
-        # Raise error to avoid silent failures
-        raise RuntimeError(f"Unexpected keys in checkpoint: {unexpected[:5]}{'...' if len(unexpected) > 5 else ''}")
-
-    # Move the whole model (including buffers not present in the checkpoint, e.g. the
-    # RoPE position-embedding buffers seq/dim_spatial_range/dim_temporal_range) onto the
-    # loading device. Under init_empty_weights() those buffers are created on meta, and
-    # load_state_dict(assign=True) only replaces keys present in the checkpoint, so they
-    # would otherwise stay off-device and break rotary attention on the GPU.
-    if loading_device.type != "cpu":
-        model.to(loading_device)
     logger.info("Loaded DiT model from %s", dit_path)
 
     return model

--- a/thenoise/dit/flux2/models.py
+++ b/thenoise/dit/flux2/models.py
@@ -25,6 +25,7 @@ import torch
 from einops import rearrange
 from torch import Tensor, nn
 
+from thenoise.dit.quantized import QuantizedLinear
 from thenoise.utils.attention import attention as sdpa_attention
 from thenoise.utils.setup_logging import setup_logging
 
@@ -216,9 +217,9 @@ class SelfAttention(nn.Module):
         super().__init__()
         self.num_heads = num_heads
         head_dim = dim // num_heads
-        self.qkv = nn.Linear(dim, dim * 3, bias=False)
+        self.qkv = QuantizedLinear(dim, dim * 3, bias=False)
         self.norm = QKNorm(head_dim)
-        self.proj = nn.Linear(dim, dim, bias=False)
+        self.proj = QuantizedLinear(dim, dim, bias=False)
 
 
 class SingleStreamBlock(nn.Module):
@@ -231,8 +232,8 @@ class SingleStreamBlock(nn.Module):
         self.mlp_hidden_dim = int(hidden_size * mlp_ratio)
         self.mlp_mult_factor = 2
 
-        self.linear1 = nn.Linear(hidden_size, hidden_size * 3 + self.mlp_hidden_dim * self.mlp_mult_factor, bias=False)
-        self.linear2 = nn.Linear(hidden_size + self.mlp_hidden_dim, hidden_size, bias=False)
+        self.linear1 = QuantizedLinear(hidden_size, hidden_size * 3 + self.mlp_hidden_dim * self.mlp_mult_factor, bias=False)
+        self.linear2 = QuantizedLinear(hidden_size + self.mlp_hidden_dim, hidden_size, bias=False)
         self.norm = QKNorm(head_dim)
         self.hidden_size = hidden_size
         self.pre_norm = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
@@ -269,18 +270,18 @@ class DoubleStreamBlock(nn.Module):
         self.img_attn = SelfAttention(dim=hidden_size, num_heads=num_heads)
         self.img_norm2 = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
         self.img_mlp = nn.Sequential(
-            nn.Linear(hidden_size, mlp_hidden_dim * self.mlp_mult_factor, bias=False),
+            QuantizedLinear(hidden_size, mlp_hidden_dim * self.mlp_mult_factor, bias=False),
             SiLUActivation(),
-            nn.Linear(mlp_hidden_dim, hidden_size, bias=False),
+            QuantizedLinear(mlp_hidden_dim, hidden_size, bias=False),
         )
 
         self.txt_norm1 = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
         self.txt_attn = SelfAttention(dim=hidden_size, num_heads=num_heads)
         self.txt_norm2 = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
         self.txt_mlp = nn.Sequential(
-            nn.Linear(hidden_size, mlp_hidden_dim * self.mlp_mult_factor, bias=False),
+            QuantizedLinear(hidden_size, mlp_hidden_dim * self.mlp_mult_factor, bias=False),
             SiLUActivation(),
-            nn.Linear(mlp_hidden_dim, hidden_size, bias=False),
+            QuantizedLinear(mlp_hidden_dim, hidden_size, bias=False),
         )
 
     @torch.compile(fullgraph=True)

--- a/thenoise/dit/flux2/utils.py
+++ b/thenoise/dit/flux2/utils.py
@@ -23,6 +23,7 @@ from accelerate import init_empty_weights
 
 from thenoise.dit.flux2.models import Flux2, Flux2Params, Klein4BParams, Klein9BParams
 from thenoise.dit.zimage.utils import QWEN3_4B_CONFIG, ZIMAGE_TOKENIZER_CONFIG_DIR
+from thenoise.utils.int8 import load_int8_if_present
 from thenoise.utils.safetensors import (
     WRAP_PREFIXES,
     MemoryEfficientSafeOpen,
@@ -68,6 +69,19 @@ QWEN3_8B_CONFIG = {
 _KLEIN_VARIANTS = {3072: Klein4BParams, 4096: Klein9BParams}
 
 
+# ComfyUI's INT8 exporter stores RMSNorm ``scale`` params under the ``weight``
+# name. Reconcile those keys so the shared loader assigns them to the model's
+# ``scale`` parameters (only the QKNorm scales carry this suffix).
+_NORM_WEIGHT_SUFFIXES = (".norm.key_norm.weight", ".norm.query_norm.weight")
+
+
+def _flux2_int8_key_map(key: str) -> str:
+    for suffix in _NORM_WEIGHT_SUFFIXES:
+        if key.endswith(suffix):
+            return key[: -len(".weight")] + ".scale"
+    return key
+
+
 def detect_klein_params(dit_path: str) -> Flux2Params:
     """Return the Klein variant params (4B / 9B) from the DiT's ``img_in`` width."""
     with MemoryEfficientSafeOpen(dit_path) as f:
@@ -102,6 +116,8 @@ def load_flux2_dit(
     logger.info(f"Loading Flux Klein DiT weights from {dit_path}")
     with torch.device("meta"):
         dit = Flux2(params)
+    if load_int8_if_present(dit, dit_path, device=device, dtype=dtype, key_map=_flux2_int8_key_map):
+        return dit
     sd = load_split_weights(dit_path, device=str(device), disable_mmap=True, dtype=dtype)
     sd = strip_wrap_prefixes(sd)
     info = dit.load_state_dict(sd, strict=True, assign=True)

--- a/thenoise/dit/flux2/utils.py
+++ b/thenoise/dit/flux2/utils.py
@@ -23,12 +23,11 @@ from accelerate import init_empty_weights
 
 from thenoise.dit.flux2.models import Flux2, Flux2Params, Klein4BParams, Klein9BParams
 from thenoise.dit.zimage.utils import QWEN3_4B_CONFIG, ZIMAGE_TOKENIZER_CONFIG_DIR
-from thenoise.utils.int8 import load_int8_if_present
+from thenoise.utils.loader import load_dit
 from thenoise.utils.safetensors import (
     WRAP_PREFIXES,
     MemoryEfficientSafeOpen,
     load_split_weights,
-    strip_wrap_prefixes,
 )
 
 logger = logging.getLogger(__name__)
@@ -111,18 +110,18 @@ def load_flux2_dit(
     device: Union[str, torch.device] = "cpu",
     dtype: torch.dtype = torch.bfloat16,
 ) -> Flux2:
-    """Build the Flux2 DiT on meta and load the checkpoint weights (assign=True)."""
+    """Build the Flux2 DiT on meta and load the checkpoint weights."""
     device = torch.device(device)
     logger.info(f"Loading Flux Klein DiT weights from {dit_path}")
     with torch.device("meta"):
         dit = Flux2(params)
-    if load_int8_if_present(dit, dit_path, device=device, dtype=dtype, key_map=_flux2_int8_key_map):
-        return dit
-    sd = load_split_weights(dit_path, device=str(device), disable_mmap=True, dtype=dtype)
-    sd = strip_wrap_prefixes(sd)
-    info = dit.load_state_dict(sd, strict=True, assign=True)
-    logger.info(f"Loaded Flux Klein DiT: {info}")
-    return dit
+    return load_dit(
+        dit,
+        dit_path,
+        device=device,
+        dtype=dtype,
+        int8_key_map=_flux2_int8_key_map,
+    )
 
 
 def _load_qwen3(

--- a/thenoise/dit/krea2/mmdit.py
+++ b/thenoise/dit/krea2/mmdit.py
@@ -16,6 +16,7 @@ import torch.nn.functional as F
 from einops import rearrange
 from torch import Tensor
 
+from thenoise.dit.quantized import QuantizedLinear
 from thenoise.utils.attention import AttentionParams, attention as common_attention
 
 
@@ -138,9 +139,9 @@ class SwiGLU(torch.nn.Module):
         mlpdim = int(2 * features / 3) * multiplier
         mlpdim = multiple * ((mlpdim + multiple - 1) // multiple)
 
-        self.gate = torch.nn.Linear(features, mlpdim, bias=bias)
-        self.up = torch.nn.Linear(features, mlpdim, bias=bias)
-        self.down = torch.nn.Linear(mlpdim, features, bias=bias)
+        self.gate = QuantizedLinear(features, mlpdim, bias=bias)
+        self.up = QuantizedLinear(features, mlpdim, bias=bias)
+        self.down = QuantizedLinear(mlpdim, features, bias=bias)
 
     def forward(self, x: Tensor) -> Tensor:
         return self.down(F.silu(self.gate(x)) * self.up(x))
@@ -153,12 +154,12 @@ class Attention(torch.nn.Module):
         self.kvheads = kvheads if kvheads is not None else heads
         self.headdim = dim // self.heads
 
-        self.wq = torch.nn.Linear(dim, self.headdim * self.heads, bias=bias)
-        self.wk = torch.nn.Linear(dim, self.headdim * self.kvheads, bias=bias)
-        self.wv = torch.nn.Linear(dim, self.headdim * self.kvheads, bias=bias)
-        self.gate = torch.nn.Linear(dim, dim, bias=bias)
+        self.wq = QuantizedLinear(dim, self.headdim * self.heads, bias=bias)
+        self.wk = QuantizedLinear(dim, self.headdim * self.kvheads, bias=bias)
+        self.wv = QuantizedLinear(dim, self.headdim * self.kvheads, bias=bias)
+        self.gate = QuantizedLinear(dim, dim, bias=bias)
         self.qknorm = QKNorm(self.headdim)
-        self.wo = torch.nn.Linear(dim, dim, bias=bias)
+        self.wo = QuantizedLinear(dim, dim, bias=bias)
 
     def forward(self, qkv: Tensor, freqs: Tensor | None = None, attn_params: AttentionParams | None = None) -> Tensor:
         q, k, v, gate = self.wq(qkv), self.wk(qkv), self.wv(qkv), self.gate(qkv)

--- a/thenoise/dit/krea2/utils.py
+++ b/thenoise/dit/krea2/utils.py
@@ -12,8 +12,7 @@ from thenoise.dit.krea2.encoder import (
     load_qwen3_vl_conditioner,
 )
 from thenoise.dit.krea2.mmdit import SingleMMDiTConfig, SingleStreamDiT
-from thenoise.utils.int8 import load_int8_if_present
-from thenoise.utils.safetensors import load_dit_safetensors
+from thenoise.utils.loader import load_dit
 
 logger = logging.getLogger(__name__)
 
@@ -43,11 +42,7 @@ def load_krea2_dit(
     config: SingleMMDiTConfig = single_mmdit_large_wide,
     loading_device: Optional[Union[str, torch.device]] = None,
 ) -> SingleStreamDiT:
-    """Build the K2 single-stream MMDiT on meta and load weights (assign=True).
-
-    bf16 only: fp8 is dropped. ``lora_weights`` (a list of loaded LoRA state dicts, with
-    optional ``lora_multipliers``) are merged into the base weights at load time.
-    """
+    """Build the K2 single-stream MMDiT on meta and load weights."""
     device = torch.device(device)
     loading_device = device if loading_device is None else torch.device(loading_device)
 
@@ -55,22 +50,13 @@ def load_krea2_dit(
     with torch.device("meta"):
         dit = SingleStreamDiT(config)
 
-    if load_int8_if_present(dit, dit_path, device=loading_device, dtype=dtype):
-        return dit
-
-    sd = load_dit_safetensors(
+    return load_dit(
+        dit,
         dit_path,
         device=loading_device,
-        disable_mmap=True,
         dtype=dtype,
-        # Some older Krea 2 checkpoints carry leftover unused ``last.down.*`` /
-        # ``last.up.*`` keys — drop them so the strict load still passes.
         drop_keys=("last.down", "last.up"),
     )
-
-    dit.load_state_dict(sd, strict=True, assign=True)
-
-    return dit
 
 
 def load_krea2_text_encoder(

--- a/thenoise/dit/krea2/utils.py
+++ b/thenoise/dit/krea2/utils.py
@@ -12,6 +12,7 @@ from thenoise.dit.krea2.encoder import (
     load_qwen3_vl_conditioner,
 )
 from thenoise.dit.krea2.mmdit import SingleMMDiTConfig, SingleStreamDiT
+from thenoise.utils.int8 import load_int8_if_present
 from thenoise.utils.safetensors import load_dit_safetensors
 
 logger = logging.getLogger(__name__)
@@ -53,6 +54,9 @@ def load_krea2_dit(
     logger.info(f"Loading Krea 2 DiT weights from {dit_path}")
     with torch.device("meta"):
         dit = SingleStreamDiT(config)
+
+    if load_int8_if_present(dit, dit_path, device=loading_device, dtype=dtype):
+        return dit
 
     sd = load_dit_safetensors(
         dit_path,

--- a/thenoise/dit/quantized.py
+++ b/thenoise/dit/quantized.py
@@ -16,6 +16,7 @@ ComfyUI-style INT8 checkpoint.
 """
 from __future__ import annotations
 
+import math
 from typing import Optional
 
 import torch
@@ -39,11 +40,14 @@ class QuantizedLinear(nn.Module):
         self.in_features = in_features
         self.out_features = out_features
         self.convrot_groupsize = convrot_groupsize
-        self.weight = nn.Parameter(torch.empty(out_features, in_features, dtype=torch.bfloat16))
+        # float32 default (matching ``nn.Linear``); the model is cast to the compute
+        # dtype (bf16) by the adapter, or the weight is replaced at load time.
+        self.weight = nn.Parameter(torch.empty(out_features, in_features))
         if bias:
-            self.bias = nn.Parameter(torch.empty(out_features, dtype=torch.bfloat16))
+            self.bias = nn.Parameter(torch.empty(out_features))
         else:
             self.register_parameter("bias", None)
+        self._reset_parameters()
         # INT8 output is always bf16; the raw op takes this as an int code (not a
         # torch.dtype), resolved once here so torch.compile never traces the dict
         # lookup. Using torch.ops.comfy_kitchen.int8_linear (a torch.library
@@ -58,6 +62,14 @@ class QuantizedLinear(nn.Module):
         self.lora_down: Optional[torch.Tensor] = None
         self.lora_up: Optional[torch.Tensor] = None
         self._lora = False
+
+    def _reset_parameters(self) -> None:
+        """Initialize like ``nn.Linear`` (kaiming on weight, uniform on bias)."""
+        nn.init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+        if self.bias is not None:
+            fan_in, _ = nn.init._calculate_fan_in_and_fan_out(self.weight)
+            bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+            nn.init.uniform_(self.bias, -bound, bound)
 
     def load_int8(
         self,

--- a/thenoise/dit/quantized.py
+++ b/thenoise/dit/quantized.py
@@ -51,6 +51,13 @@ class QuantizedLinear(nn.Module):
         # Python wrapper keeps the call traceable inside ``torch.compile``.
         self._out_dtype_code = comfy_kitchen.DTYPE_TO_CODE[torch.bfloat16]
         self._int8 = False
+        # Rank-reduced bf16 LoRA residual branch (INT8 path only): ``lora_down``
+        # is ``[r, in]`` (already scaled), ``lora_up`` is ``[out, r]``. Multiple
+        # LoRAs are concatenated along the rank dim so forward keeps one fixed
+        # structure. bf16 layers use the normal parameter-mutation LoRA path.
+        self.lora_down: Optional[torch.Tensor] = None
+        self.lora_up: Optional[torch.Tensor] = None
+        self._lora = False
 
     def load_int8(
         self,
@@ -72,11 +79,46 @@ class QuantizedLinear(nn.Module):
         self.register_parameter("weight", None)  # free the BF16 weights
         self._int8 = True
 
+    def apply_lora(self, down, up, alpha, multiplier, calc_device) -> None:
+        """Store a rank-reduced bf16 LoRA residual branch (INT8 path only).
+
+        Args:
+            down: LoRA-down ``[r, in]`` (bf16/fp16).
+            up: LoRA-up ``[out, r]`` (bf16/fp16).
+            alpha: LoRA alpha (scalar, int, or 0-dim tensor).
+            multiplier: LoRA weight multiplier.
+            calc_device: device to store the factors on.
+
+        The residual added in ``forward`` is ``x @ down^T @ up^T * (alpha/r) *
+        multiplier``, matching ``_compute_lora_delta``'s ``multiplier * (up @
+        down) * scale``. Multiple LoRAs are concatenated along the rank dim so
+        the forward residual keeps a single fixed shape.
+        """
+        r = down.size(0)
+        scale = (
+            float(alpha.to(calc_device)) if isinstance(alpha, torch.Tensor) else float(alpha)
+        ) / r * multiplier
+        down = down.to(device=calc_device, dtype=torch.bfloat16)
+        up = up.to(device=calc_device, dtype=torch.bfloat16)
+        scaled_down = down * scale
+        if self._lora:
+            self.lora_down = torch.cat([self.lora_down, scaled_down], dim=0)
+            self.lora_up = torch.cat([self.lora_up, up], dim=1)
+        else:
+            self.lora_down = scaled_down
+            self.lora_up = up
+            self._lora = True
+
+    def clear_lora(self) -> None:
+        self.lora_down = None
+        self.lora_up = None
+        self._lora = False
+
     def forward(self, x: torch.Tensor, input_act: Optional[str] = None) -> torch.Tensor:
         if self._int8:
             # Call the raw custom op (traceable by torch.compile) rather than the
             # registry-dispatching comfy_kitchen.int8_linear Python wrapper.
-            return torch.ops.comfy_kitchen.int8_linear(
+            out = torch.ops.comfy_kitchen.int8_linear(
                 x,
                 self.qweight,
                 self.scale,
@@ -86,6 +128,11 @@ class QuantizedLinear(nn.Module):
                 self.convrot_groupsize,
                 input_act,
             )
+            if self._lora:
+                # bf16 LoRA residual branch: x @ down^T @ up^T (scale folded into
+                # lora_down). Keeps the int8 weight untouched.
+                out = out + x @ self.lora_down.t() @ self.lora_up.t()
+            return out
         return F.linear(x, self.weight, self.bias)
 
 

--- a/thenoise/dit/quantized.py
+++ b/thenoise/dit/quantized.py
@@ -1,0 +1,92 @@
+"""Reusable INT8+ConvRot linear projection.
+
+``QuantizedLinear`` is a drop-in replacement for ``nn.Linear`` on layers a model
+wants to run as symmetric INT8 with online ConvRot (Hadamard) activation rotation
+via the ``comfy_kitchen`` INT8 GEMM (``torch.ops.comfy_kitchen.int8_linear``). The
+compute path is chosen at load time: a layer that keeps its BF16 ``weight`` runs
+``F.linear``; a layer switched with ``load_int8`` runs the INT8 kernel and frees
+the BF16 weight. Quantized layers emit BF16 output, so everything downstream is
+dtype-agnostic and the rest of the model needs no changes.
+
+INT8 weights are stored in buffers (not parameters) because PyTorch forbids
+gradients on integer tensors — ``load_state_dict(assign=True)`` cannot assign an
+int8 tensor into an ``nn.Parameter``. Loaders should use
+``thenoise.utils.int8.load_int8_state_dict`` to populate the model from a
+ComfyUI-style INT8 checkpoint.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import comfy_kitchen
+
+
+class QuantizedLinear(nn.Module):
+    """Linear projection that runs BF16 (default) or INT8+ConvRot."""
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        bias: bool = False,
+        convrot_groupsize: int = 256,
+    ) -> None:
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.convrot_groupsize = convrot_groupsize
+        self.weight = nn.Parameter(torch.empty(out_features, in_features, dtype=torch.bfloat16))
+        if bias:
+            self.bias = nn.Parameter(torch.empty(out_features, dtype=torch.bfloat16))
+        else:
+            self.register_parameter("bias", None)
+        # INT8 output is always bf16; the raw op takes this as an int code (not a
+        # torch.dtype), resolved once here so torch.compile never traces the dict
+        # lookup. Using torch.ops.comfy_kitchen.int8_linear (a torch.library
+        # custom op with a fake schema) instead of the comfy_kitchen.int8_linear
+        # Python wrapper keeps the call traceable inside ``torch.compile``.
+        self._out_dtype_code = comfy_kitchen.DTYPE_TO_CODE[torch.bfloat16]
+        self._int8 = False
+
+    def load_int8(
+        self,
+        qweight: torch.Tensor,
+        scale: torch.Tensor,
+        convrot_groupsize: Optional[int] = None,
+    ) -> None:
+        """Switch this layer to INT8+ConvRot using pre-quantized weights.
+
+        Args:
+            qweight: int8 weight tensor ``[out, in]``.
+            scale: per-row F32 scale ``[out]`` (or ``[out, 1]``).
+            convrot_groupsize: Hadamard group size (defaults to 256).
+        """
+        self.register_buffer("qweight", qweight)
+        self.register_buffer("scale", scale)
+        if convrot_groupsize is not None:
+            self.convrot_groupsize = convrot_groupsize
+        self.register_parameter("weight", None)  # free the BF16 weights
+        self._int8 = True
+
+    def forward(self, x: torch.Tensor, input_act: Optional[str] = None) -> torch.Tensor:
+        if self._int8:
+            # Call the raw custom op (traceable by torch.compile) rather than the
+            # registry-dispatching comfy_kitchen.int8_linear Python wrapper.
+            return torch.ops.comfy_kitchen.int8_linear(
+                x,
+                self.qweight,
+                self.scale,
+                self.bias,
+                self._out_dtype_code,
+                True,  # convrot
+                self.convrot_groupsize,
+                input_act,
+            )
+        return F.linear(x, self.weight, self.bias)
+
+
+__all__ = ["QuantizedLinear"]

--- a/thenoise/dit/zimage/models.py
+++ b/thenoise/dit/zimage/models.py
@@ -14,6 +14,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from thenoise.dit.quantized import QuantizedLinear
 from thenoise.utils.attention import AttentionParams, attention
 from thenoise.utils.setup_logging import setup_logging
 
@@ -83,16 +84,19 @@ class Attention(nn.Module):
         super().__init__()
         self.n_heads = n_heads
         self.head_dim = dim // n_heads
-        self.qkv = nn.Linear(dim, 3 * dim, bias=False)
-        self.out = nn.Linear(dim, dim, bias=False)
+        self.qkv = QuantizedLinear(dim, 3 * dim, bias=False)
+        self.out = QuantizedLinear(dim, dim, bias=False)
         self.q_norm = RMSNorm(self.head_dim, eps=eps) if qk_norm else nn.Identity()
         self.k_norm = RMSNorm(self.head_dim, eps=eps) if qk_norm else nn.Identity()
 
     def _apply_rotary_emb(self, x, freqs_cis):
+        x_dtype = x.dtype
         x = torch.view_as_complex(x.float().reshape(*x.shape[:-1], -1, 2))
         freqs_cis = freqs_cis.unsqueeze(2)
         x_out = torch.view_as_real(x * freqs_cis).flatten(3)
-        return x_out.type_as(self.out.weight)
+        # Cast back to the activation dtype (bf16); the int8 ``out`` projection has
+        # no bf16 ``weight`` to reference for the dtype.
+        return x_out.to(x_dtype)
 
     def forward(self, hidden_states, attention_mask=None, freqs_cis=None):
         dim = hidden_states.shape[-1]
@@ -126,9 +130,9 @@ class FeedForward(nn.Module):
 
     def __init__(self, dim, hidden_dim):
         super().__init__()
-        self.w1 = nn.Linear(dim, hidden_dim, bias=False)
-        self.w2 = nn.Linear(hidden_dim, dim, bias=False)
-        self.w3 = nn.Linear(dim, hidden_dim, bias=False)
+        self.w1 = QuantizedLinear(dim, hidden_dim, bias=False)
+        self.w2 = QuantizedLinear(hidden_dim, dim, bias=False)
+        self.w3 = QuantizedLinear(dim, hidden_dim, bias=False)
 
     def forward(self, x):
         return self.w2(F.silu(self.w1(x)) * self.w3(x))
@@ -149,7 +153,7 @@ class ZImageTransformerBlock(nn.Module):
 
         self.modulation = modulation
         if modulation:
-            self.adaLN_modulation = nn.Sequential(nn.Linear(min(dim, ADALN_EMBED_DIM), 4 * dim, bias=True))
+            self.adaLN_modulation = nn.Sequential(QuantizedLinear(min(dim, ADALN_EMBED_DIM), 4 * dim, bias=True))
 
     @torch.compile(fullgraph=True)
     def forward(self, x, attn_mask, freqs_cis, adaln_input=None):

--- a/thenoise/dit/zimage/utils.py
+++ b/thenoise/dit/zimage/utils.py
@@ -17,8 +17,8 @@ from typing import Optional, Union
 import torch
 
 from thenoise.dit.zimage.models import ZImageTransformer2DModel
-from thenoise.utils.int8 import load_int8_if_present
-from thenoise.utils.safetensors import load_split_weights, strip_wrap_prefixes
+from thenoise.utils.loader import load_dit
+from thenoise.utils.safetensors import load_split_weights
 
 logger = logging.getLogger(__name__)
 
@@ -86,11 +86,7 @@ def load_zimage_dit(
     loading_device: Optional[Union[str, torch.device]] = None,
     config: Optional[dict] = None,
 ) -> ZImageTransformer2DModel:
-    """Build the Z-Image S3-DiT on meta and load weights (assign=True).
-
-    Accepts a single-file checkpoint (e.g. ComfyUI's ``z_image_turbo_bf16.safetensors``)
-    or a sharded HF checkpoint (pass any ``model-0000X-of-0000Y`` shard path).
-    """
+    """Build the Z-Image S3-DiT on meta and load weights."""
     device = torch.device(device)
     loading_device = device if loading_device is None else torch.device(loading_device)
     cfg = dict(ZIMAGE_DIT_CONFIG)
@@ -101,14 +97,7 @@ def load_zimage_dit(
     with torch.device("meta"):
         dit = ZImageTransformer2DModel(**cfg)
 
-    if load_int8_if_present(dit, dit_path, device=loading_device, dtype=dtype):
-        return dit
-
-    sd = load_split_weights(dit_path, device=str(loading_device), disable_mmap=True, dtype=dtype)
-    sd = strip_wrap_prefixes(sd)
-
-    dit.load_state_dict(sd, strict=True, assign=True)
-    return dit
+    return load_dit(dit, dit_path, device=loading_device, dtype=dtype)
 
 
 def _load_qwen3(

--- a/thenoise/dit/zimage/utils.py
+++ b/thenoise/dit/zimage/utils.py
@@ -17,6 +17,7 @@ from typing import Optional, Union
 import torch
 
 from thenoise.dit.zimage.models import ZImageTransformer2DModel
+from thenoise.utils.int8 import load_int8_if_present
 from thenoise.utils.safetensors import load_split_weights, strip_wrap_prefixes
 
 logger = logging.getLogger(__name__)
@@ -99,6 +100,9 @@ def load_zimage_dit(
     logger.info(f"Loading Z-Image DiT weights from {dit_path}")
     with torch.device("meta"):
         dit = ZImageTransformer2DModel(**cfg)
+
+    if load_int8_if_present(dit, dit_path, device=loading_device, dtype=dtype):
+        return dit
 
     sd = load_split_weights(dit_path, device=str(loading_device), disable_mmap=True, dtype=dtype)
     sd = strip_wrap_prefixes(sd)

--- a/thenoise/utils/int8.py
+++ b/thenoise/utils/int8.py
@@ -1,0 +1,112 @@
+"""INT8 (INT8+ConvRot) checkpoint loading helpers, shared across models.
+
+The INT8 ConvRot checkpoints produced by ComfyUI's exporter store each quantized
+linear as three tensors: an int8 ``.weight``, a per-row F32 ``.weight_scale``,
+and a small U8 ``.comfy_quant`` metadata marker (not needed at inference). Layers
+kept in full precision stay as plain BF16 ``.weight``/``.bias``.
+
+These helpers are model-agnostic: any module exposing a ``load_int8(qweight,
+scale)`` method (e.g. ``thenoise.dit.quantized.QuantizedLinear``) is switched to
+INT8 at load time; every other layer is assigned normally.
+"""
+from __future__ import annotations
+
+import logging
+
+import torch
+
+from thenoise.utils.safetensors import MemoryEfficientSafeOpen, WRAP_PREFIXES
+from thenoise.utils.setup_logging import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+# Suffix used by ComfyUI's INT8 exporter for the per-row weight scale.
+_WEIGHT_SCALE_SUFFIX = ".weight_scale"
+# U8 marker ComfyUI stores per quantized layer; not needed at inference.
+_COMFY_QUANT_SUFFIX = ".comfy_quant"
+
+
+def is_int8_checkpoint(dit_path: str) -> bool:
+    """Return True if ``dit_path`` is an INT8+ConvRot checkpoint.
+
+    Detects the presence of any ``.weight_scale`` key in the safetensors header
+    (after stripping generic repackaging wrapper prefixes). Reads the header
+    only — no tensors are loaded.
+    """
+    with MemoryEfficientSafeOpen(dit_path) as f:
+        for key in f.keys():
+            for prefix in WRAP_PREFIXES:
+                if key.startswith(prefix):
+                    key = key[len(prefix):]
+                    break
+            if key.endswith(_WEIGHT_SCALE_SUFFIX):
+                return True
+    return False
+
+
+def load_int8_state_dict(model: torch.nn.Module, state_dict: dict[str, torch.Tensor]) -> None:
+    """Populate ``model`` from an INT8+ConvRot state dict.
+
+    Quantized linear weights (int8 ``.weight`` paired with a per-row
+    ``.weight_scale``) land on modules that implement ``load_int8``; every other
+    layer (kept in full precision) is assigned as a plain BF16 ``.weight``/
+    ``.bias``. ``comfy_quant`` metadata markers are ignored.
+
+    ``state_dict`` must already have generic wrapper prefixes stripped (see
+    ``thenoise.utils.safetensors.load_dit_safetensors``).
+    """
+    # Scales are collected before weights are processed: an int8 ``.weight``
+    # needs its per-row ``.weight_scale``, and dict order is not guaranteed to
+    # place the scale before the weight it belongs to.
+    scales: dict[str, torch.Tensor] = {}
+    for key, tensor in state_dict.items():
+        if key.endswith(_WEIGHT_SCALE_SUFFIX):
+            scales[key[: -len(_WEIGHT_SCALE_SUFFIX)]] = tensor
+
+    for key, tensor in state_dict.items():
+        if key.endswith(_WEIGHT_SCALE_SUFFIX) or key.endswith(_COMFY_QUANT_SUFFIX):
+            continue
+        module_path, _, attr = key.rpartition(".")
+        module = _submodule(model, module_path, key)
+        if attr == "weight":
+            if tensor.dtype == torch.int8:
+                _switch_to_int8(module, tensor, scales.pop(module_path, None), key)
+            else:
+                # Replace the (meta, init-time) parameter with the loaded tensor
+                # rather than ``param.data = ...``: set_data rejects meta params
+                # and dtype mismatches (the int8 path skips model.to(dtype)).
+                module.weight = torch.nn.Parameter(tensor)
+        elif attr == "bias":
+            module.bias = torch.nn.Parameter(tensor)
+        else:
+            raise RuntimeError(f"unexpected key in INT8 checkpoint: {key!r}")
+
+    if scales:
+        raise RuntimeError(
+            f"orphan {_WEIGHT_SCALE_SUFFIX} keys in INT8 checkpoint: {list(scales)[:5]}"
+        )
+
+
+def _submodule(model: torch.nn.Module, module_path: str, key: str) -> torch.nn.Module:
+    """Resolve a checkpoint key's module path, with a clear error on mismatch."""
+    try:
+        return model.get_submodule(module_path)
+    except AttributeError as e:
+        raise RuntimeError(
+            f"INT8 checkpoint key {key!r} does not match the model structure: {e}"
+        ) from e
+
+
+def _switch_to_int8(module: torch.nn.Module, qweight: torch.Tensor, scale, key: str) -> None:
+    if scale is None:
+        raise RuntimeError(f"INT8 weight {key!r} is missing its {_WEIGHT_SCALE_SUFFIX}")
+    if not hasattr(module, "load_int8"):
+        raise RuntimeError(
+            f"INT8 weight {key!r} landed on {type(module).__name__}, "
+            "which has no load_int8(); it must be a QuantizedLinear"
+        )
+    module.load_int8(qweight, scale)
+
+
+__all__ = ["is_int8_checkpoint", "load_int8_state_dict"]

--- a/thenoise/utils/int8.py
+++ b/thenoise/utils/int8.py
@@ -12,10 +12,15 @@ INT8 at load time; every other layer is assigned normally.
 from __future__ import annotations
 
 import logging
+from typing import Optional, Union
 
 import torch
 
-from thenoise.utils.safetensors import MemoryEfficientSafeOpen, WRAP_PREFIXES
+from thenoise.utils.safetensors import (
+    MemoryEfficientSafeOpen,
+    WRAP_PREFIXES,
+    load_dit_safetensors,
+)
 from thenoise.utils.setup_logging import setup_logging
 
 setup_logging()
@@ -45,13 +50,19 @@ def is_int8_checkpoint(dit_path: str) -> bool:
     return False
 
 
-def load_int8_state_dict(model: torch.nn.Module, state_dict: dict[str, torch.Tensor]) -> None:
+def load_int8_state_dict(
+    model: torch.nn.Module,
+    state_dict: dict[str, torch.Tensor],
+    dtype: Optional[torch.dtype] = None,
+) -> None:
     """Populate ``model`` from an INT8+ConvRot state dict.
 
     Quantized linear weights (int8 ``.weight`` paired with a per-row
     ``.weight_scale``) land on modules that implement ``load_int8``; every other
-    layer (kept in full precision) is assigned as a plain BF16 ``.weight``/
-    ``.bias``. ``comfy_quant`` metadata markers are ignored.
+    leaf parameter (kept in full precision — ``weight``/``bias``/embedding tokens
+    etc.) is replaced with the loaded tensor, cast to ``dtype`` when given (the
+    INT8 kernels emit BF16, so full-precision params must match). ``comfy_quant``
+    metadata markers are ignored.
 
     ``state_dict`` must already have generic wrapper prefixes stripped (see
     ``thenoise.utils.safetensors.load_dit_safetensors``).
@@ -69,16 +80,15 @@ def load_int8_state_dict(model: torch.nn.Module, state_dict: dict[str, torch.Ten
             continue
         module_path, _, attr = key.rpartition(".")
         module = _submodule(model, module_path, key)
-        if attr == "weight":
-            if tensor.dtype == torch.int8:
-                _switch_to_int8(module, tensor, scales.pop(module_path, None), key)
-            else:
-                # Replace the (meta, init-time) parameter with the loaded tensor
-                # rather than ``param.data = ...``: set_data rejects meta params
-                # and dtype mismatches (the int8 path skips model.to(dtype)).
-                module.weight = torch.nn.Parameter(tensor)
-        elif attr == "bias":
-            module.bias = torch.nn.Parameter(tensor)
+        if attr == "weight" and tensor.dtype == torch.int8:
+            _switch_to_int8(module, tensor, scales.pop(module_path, None), key)
+        elif isinstance(getattr(module, attr, None), torch.nn.Parameter):
+            # BF16/full-precision leaf parameter (weight, bias, pad tokens, ...):
+            # replace the (meta, init-time) parameter rather than ``param.data =
+            # ...``, because set_data rejects meta params and dtype mismatches.
+            if dtype is not None:
+                tensor = tensor.to(dtype=dtype)
+            setattr(module, attr, torch.nn.Parameter(tensor))
         else:
             raise RuntimeError(f"unexpected key in INT8 checkpoint: {key!r}")
 
@@ -109,4 +119,36 @@ def _switch_to_int8(module: torch.nn.Module, qweight: torch.Tensor, scale, key: 
     module.load_int8(qweight, scale)
 
 
-__all__ = ["is_int8_checkpoint", "load_int8_state_dict"]
+def load_int8_if_present(
+    model: torch.nn.Module,
+    dit_path: str,
+    *,
+    device: Union[str, torch.device],
+    dtype: Optional[torch.dtype] = None,
+    key_map: Optional[callable] = None,
+) -> bool:
+    """Load an INT8+ConvRot checkpoint into ``model`` if ``dit_path`` is one.
+
+    Centralizes the INT8 detection + loading shared by every model adapter: if
+    the checkpoint is INT8 it is fully loaded (native int8 weights/scales, full-
+    precision params cast to ``dtype``) and True is returned; otherwise the
+    caller loads the BF16 checkpoint as usual and False is returned. Handles the
+    final device move of buffers/parameters.
+
+    ``key_map`` (optional) transforms checkpoint keys before loading; it is used
+    to reconcile exporter-specific renames (e.g. ComfyUI's INT8 exporter stores
+    norm ``scale`` params under ``weight``).
+    """
+    if not is_int8_checkpoint(dit_path):
+        return False
+    device = torch.device(device)
+    sd = load_dit_safetensors(dit_path, device=device, disable_mmap=True, dtype=None)
+    if key_map is not None:
+        sd = {key_map(k): v for k, v in sd.items()}
+    load_int8_state_dict(model, sd, dtype=dtype)
+    model.to(device)
+    logger.info("Loaded INT8+ConvRot checkpoint from %s", dit_path)
+    return True
+
+
+__all__ = ["is_int8_checkpoint", "load_int8_state_dict", "load_int8_if_present"]

--- a/thenoise/utils/int8.py
+++ b/thenoise/utils/int8.py
@@ -12,15 +12,11 @@ INT8 at load time; every other layer is assigned normally.
 from __future__ import annotations
 
 import logging
-from typing import Optional, Union
+from typing import Optional
 
 import torch
 
-from thenoise.utils.safetensors import (
-    MemoryEfficientSafeOpen,
-    WRAP_PREFIXES,
-    load_dit_safetensors,
-)
+from thenoise.utils.safetensors import MemoryEfficientSafeOpen, WRAP_PREFIXES
 from thenoise.utils.setup_logging import setup_logging
 
 setup_logging()
@@ -119,36 +115,4 @@ def _switch_to_int8(module: torch.nn.Module, qweight: torch.Tensor, scale, key: 
     module.load_int8(qweight, scale)
 
 
-def load_int8_if_present(
-    model: torch.nn.Module,
-    dit_path: str,
-    *,
-    device: Union[str, torch.device],
-    dtype: Optional[torch.dtype] = None,
-    key_map: Optional[callable] = None,
-) -> bool:
-    """Load an INT8+ConvRot checkpoint into ``model`` if ``dit_path`` is one.
-
-    Centralizes the INT8 detection + loading shared by every model adapter: if
-    the checkpoint is INT8 it is fully loaded (native int8 weights/scales, full-
-    precision params cast to ``dtype``) and True is returned; otherwise the
-    caller loads the BF16 checkpoint as usual and False is returned. Handles the
-    final device move of buffers/parameters.
-
-    ``key_map`` (optional) transforms checkpoint keys before loading; it is used
-    to reconcile exporter-specific renames (e.g. ComfyUI's INT8 exporter stores
-    norm ``scale`` params under ``weight``).
-    """
-    if not is_int8_checkpoint(dit_path):
-        return False
-    device = torch.device(device)
-    sd = load_dit_safetensors(dit_path, device=device, disable_mmap=True, dtype=None)
-    if key_map is not None:
-        sd = {key_map(k): v for k, v in sd.items()}
-    load_int8_state_dict(model, sd, dtype=dtype)
-    model.to(device)
-    logger.info("Loaded INT8+ConvRot checkpoint from %s", dit_path)
-    return True
-
-
-__all__ = ["is_int8_checkpoint", "load_int8_state_dict", "load_int8_if_present"]
+__all__ = ["is_int8_checkpoint", "load_int8_state_dict"]

--- a/thenoise/utils/loader.py
+++ b/thenoise/utils/loader.py
@@ -1,0 +1,108 @@
+"""Central quant-aware DiT loader.
+
+Every DiT adapter loads its weights through a single entry point,
+``load_dit``, which automatically selects the correct quantization:
+
+* **INT8+ConvRot** checkpoint (detected via ``is_int8_checkpoint``): weights
+  land via ``load_int8_state_dict`` — quantized linears on modules exposing
+  ``load_int8`` (``QuantizedLinear``), full-precision params cast to ``dtype``.
+* **BF16 / plain** checkpoint: weights land via ``load_state_dict(assign=True)``,
+  with the loaded tensors cast to ``dtype``.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Callable, Optional, Union
+
+import torch
+
+from thenoise.utils.int8 import is_int8_checkpoint, load_int8_state_dict
+from thenoise.utils.safetensors import load_dit_safetensors
+from thenoise.utils.setup_logging import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+
+def load_dit(
+    model: torch.nn.Module,
+    path: str,
+    *,
+    device: Union[str, torch.device],
+    dtype: Optional[torch.dtype] = None,
+    drop_keys: Optional[tuple[str, ...]] = None,
+    expected_missing: tuple[str, ...] = (),
+    int8_key_map: Optional[Callable[[str], str]] = None,
+) -> torch.nn.Module:
+    """Load a DiT checkpoint into ``model``, selecting INT8 vs BF16 automatically.
+
+    Args:
+        model: the (meta-constructed) DiT to populate.
+        path: safetensors checkpoint path.
+        device: final device for all parameters/buffers.
+        dtype: dtype for full-precision (BF16-path and INT8 non-quantized) params.
+        drop_keys: optional tuple of key prefixes to drop from the checkpoint
+            before loading (e.g. Krea2's unused ``last.down``/``last.up``).
+            Applied on BOTH the INT8 and BF16 paths.
+        expected_missing: optional substrings allowed to be absent from the
+            checkpoint (model-internal buffers, e.g. Anima's RoPE buffers). If
+            non-empty the load is non-strict and only these are tolerated;
+            otherwise loading is strict.
+        int8_key_map: optional transform applied to checkpoint keys on the INT8
+            path only (e.g. Flux Klein's ComfyUI norm ``weight`` -> ``scale``
+            rename). BF16 checkpoints carry the canonical names already.
+
+    Returns:
+        ``model`` (loaded in place, moved to ``device``).
+    """
+    device = torch.device(device)
+
+    # Load the state dict once (stripping generic wrapper prefixes inside
+    # ``load_dit_safetensors``) and apply ``drop_keys`` before branching, so the
+    # INT8 and BF16 paths see the same prepared dict.
+    sd = load_dit_safetensors(path, device=device, disable_mmap=True, dtype=None)
+    if drop_keys:
+        sd = {k: v for k, v in sd.items() if not k.startswith(drop_keys)}
+
+    if is_int8_checkpoint(path):
+        if int8_key_map is not None:
+            sd = {int8_key_map(k): v for k, v in sd.items()}
+        load_int8_state_dict(model, sd, dtype=dtype)
+        logger.info("Loaded INT8+ConvRot checkpoint from %s", path)
+    else:
+        if dtype is not None:
+            sd = {k: v.to(dtype=dtype) for k, v in sd.items()}
+        _load_bf16(model, sd, expected_missing, path)
+
+    # Move the whole model onto the device, including buffers not present in the
+    # checkpoint (e.g. RoPE position-embedding buffers that were created on meta
+    # and are not saved in the file).
+    model.to(device)
+    return model
+
+
+def _load_bf16(
+    model: torch.nn.Module,
+    sd: dict[str, torch.Tensor],
+    expected_missing: tuple[str, ...],
+    path: str,
+) -> None:
+    """Load a plain/BF16 state dict, strict unless ``expected_missing`` is set."""
+    if expected_missing:
+        info = model.load_state_dict(sd, strict=False, assign=True)
+        missing = [
+            k for k in info.missing_keys
+            if not any(buf in k for buf in expected_missing)
+        ]
+        if missing or info.unexpected_keys:
+            raise RuntimeError(
+                f"checkpoint {path!r} did not match the model: "
+                f"missing={missing[:10]}, "
+                f"unexpected={info.unexpected_keys[:10]}"
+            )
+    else:
+        model.load_state_dict(sd, strict=True, assign=True)
+    logger.info("Loaded BF16 checkpoint from %s", path)
+
+
+__all__ = ["load_dit"]

--- a/thenoise/utils/lora.py
+++ b/thenoise/utils/lora.py
@@ -3,6 +3,7 @@ import re
 from typing import Dict, List, Optional, Tuple, TypedDict, Union
 import torch
 
+from thenoise.dit.quantized import QuantizedLinear
 from thenoise.utils.setup_logging import setup_logging
 
 setup_logging()
@@ -180,13 +181,17 @@ class LoRAApplyResult(TypedDict):
 
     Keeps the small rank-reduced LoRA factors in memory instead of full-sized
     delta tensors.  On undo the deltas are recomputed from these factors.
-    ``affected_keys`` tracks exactly which model parameters were modified,
-    so undo can skip the unaffected ones without iterating the full state dict.
+    ``affected_keys`` tracks exactly which model parameters were modified, so
+    undo can skip the unaffected ones without iterating the full state dict.
+    ``int8_affected`` lists the INT8 ``QuantizedLinear`` module paths whose LoRA
+    residual branch was populated (see ``thenoise.dit.quantized``); undo calls
+    ``clear_lora`` on them.
     """
 
     lora_sds: List[Dict[str, torch.Tensor]]
     multipliers: List[float]
     affected_keys: Tuple[str, ...]
+    int8_affected: Tuple[str, ...]
 
 
 def apply_lora_to_model(
@@ -205,7 +210,7 @@ def apply_lora_to_model(
     Param keys use the same naming as ``model.state_dict()`` (e.g. "blocks.0.attn.gate.weight").
     """
     if not lora_sds:
-        return {"lora_sds": [], "multipliers": []}
+        return {"lora_sds": [], "multipliers": [], "affected_keys": (), "int8_affected": ()}
 
     if multipliers is None:
         multipliers = [1.0] * len(lora_sds)
@@ -263,6 +268,32 @@ def apply_lora_to_model(
             if alpha_key in lora_weight_keys:
                 lora_weight_keys.remove(alpha_key)
 
+    # INT8 QuantizedLinear layers have no bf16 ``.weight`` parameter to mutate;
+    # their LoRA is applied as a separate bf16 residual branch stored on the
+    # module (``apply_lora``), keeping the int8 weight untouched. This must run
+    # before the unused-key warning so the consumed keys are not reported.
+    int8_affected: List[str] = []
+    for module_path, module in base_model.named_modules():
+        if not isinstance(module, QuantizedLinear) or not module._int8:
+            continue
+        model_key = f"{module_path}.weight"
+        for lora_weight_keys, lora_sd, multiplier in zip(lora_weight_keys_list, lora_sds, multipliers):
+            match = _match_lora_keys(model_key, lora_weight_keys)
+            if match is None:
+                continue
+            down_key, up_key, alpha_key = match
+            module.apply_lora(
+                lora_sd[down_key],
+                lora_sd[up_key],
+                lora_sd.get(alpha_key, lora_sd[down_key].size(0)),
+                multiplier,
+                calc_device,
+            )
+            lora_weight_keys.discard(down_key)
+            lora_weight_keys.discard(up_key)
+            lora_weight_keys.discard(alpha_key)
+            int8_affected.append(module_path)
+
     # Warn about unused LoRA keys
     for i, lora_weight_keys in enumerate(lora_weight_keys_list):
         if len(lora_weight_keys) > 0:
@@ -279,6 +310,7 @@ def apply_lora_to_model(
         "lora_sds": lora_sds,
         "multipliers": multipliers,
         "affected_keys": tuple(undo_deltas.keys()),
+        "int8_affected": tuple(dict.fromkeys(int8_affected)),
     }
 
 
@@ -297,11 +329,22 @@ def undo_lora_on_model(
     lora_sds = result["lora_sds"]
     multipliers = result["multipliers"]
     affected_keys = result.get("affected_keys")
+    int8_affected = result.get("int8_affected")
+    if not lora_sds and not int8_affected:
+        return
+
+    base_model = _unwrap_compiled(model)
+
+    # INT8 residual LoRAs: just drop the stored factors on the module.
+    for module_path in int8_affected or ():
+        module = base_model.get_submodule(module_path)
+        if hasattr(module, "clear_lora"):
+            module.clear_lora()
+
     if not lora_sds or not affected_keys:
         return
 
     logger.debug("Undoing LoRA on model (%d LoRA(s), %d keys)", len(lora_sds), len(affected_keys))
-    base_model = _unwrap_compiled(model)
 
     # Build key sets for each LoRA (copy so we can mutate)
     lora_weight_keys_list = [set(sd.keys()) for sd in lora_sds]

--- a/thenoise/utils/safetensors.py
+++ b/thenoise/utils/safetensors.py
@@ -290,7 +290,8 @@ def load_safetensors(
         with MemoryEfficientSafeOpen(path, disable_numpy_memmap=disable_numpy_memmap) as f:
             for key in f.keys():
                 state_dict[key] = f.get_tensor(key, device=device, dtype=dtype)
-            torch.cuda.synchronize()
+            if device is not None and device.type == "cuda":
+                torch.cuda.synchronize()
         return state_dict
     else:
         try:


### PR DESCRIPTION
Reduce memory usage and improves computation on specific hardware.

On Strix Halo (gfx1151) only Krea 2 Turbo benefits from this, 1024x768 @ Steps goes from ~26 seconds down to ~22 seconds. Other models have about the same performance

On Strix Point (gfx1150) all models benefit from using int8convrot weights