### PR TITLE
Remove pervasive defaults

### DIFF
--- a/tests/test_upscale.py
+++ b/tests/test_upscale.py
@@ -125,7 +125,7 @@ def _make_upscale_controller(upscaler_dir="/tmp", scales=None):
     """Build a PixelUpscaleController over an injected-scale manager."""
     from thenoise.upscale_controller import PixelUpscaleController
 
-    m = PixelUpscalerManager(upscaler_dir=upscaler_dir)
+    m = PixelUpscalerManager(upscaler_dir=upscaler_dir, device="cpu")
     m._pixel_upscaler_scales = dict(scales or {})
     return PixelUpscaleController(m)
 

--- a/tests/test_zimage.py
+++ b/tests/test_zimage.py
@@ -100,8 +100,9 @@ def test_flux_upscaler_loads_and_runs():
 
 def test_load_upscaler_rejects_unknown_format():
     import pytest
+    import torch
 
     from thenoise.upscale import load_latent_upscaler
 
     with pytest.raises(ValueError):
-        load_latent_upscaler("not_a_real_format")
+        load_latent_upscaler("not_a_real_format", device="cpu", dtype=torch.bfloat16)

--- a/thenoise/dit/anima/models.py
+++ b/thenoise/dit/anima/models.py
@@ -1087,8 +1087,7 @@ class AdapterRotaryEmbedding(nn.Module):
         inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
         position_ids_expanded = position_ids[:, None, :].float()
 
-        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
-        with torch.autocast(device_type=device_type, enabled=False):
+        with torch.autocast(device_type=x.device.type, enabled=False):
             freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
             emb = torch.cat((freqs, freqs), dim=-1)
             cos = emb.cos()

--- a/thenoise/dit/anima/utils.py
+++ b/thenoise/dit/anima/utils.py
@@ -147,8 +147,8 @@ def load_qwen3_tokenizer(qwen3_path: str):
 
 def load_qwen3_text_encoder(
     qwen3_path: str,
-    dtype: torch.dtype = torch.bfloat16,
-    device: str = "cpu",
+    dtype: Union[str, torch.device],
+    device: str,
     lora_weights: Optional[List[Dict[str, torch.Tensor]]] = None,
     lora_multipliers: Optional[List[float]] = None,
 ):

--- a/thenoise/dit/flux2/utils.py
+++ b/thenoise/dit/flux2/utils.py
@@ -107,8 +107,8 @@ def detect_klein_params(dit_path: str) -> Flux2Params:
 def load_flux2_dit(
     dit_path: str,
     params: Flux2Params,
-    device: Union[str, torch.device] = "cpu",
-    dtype: torch.dtype = torch.bfloat16,
+    device: Union[str, torch.device],
+    dtype: torch.dtype,
 ) -> Flux2:
     """Build the Flux2 DiT on meta and load the checkpoint weights."""
     device = torch.device(device)
@@ -195,8 +195,8 @@ class Qwen3Embedder:
 def load_qwen3_embedder(
     path: str,
     is_8b: bool,
-    dtype: torch.dtype = torch.bfloat16,
-    device: Union[str, torch.device] = "cpu",
+    dtype: torch.dtype,
+    device: Union[str, torch.device],
     tokenizer_dir: Optional[str] = None,
 ) -> Qwen3Embedder:
     """Load the Qwen3 text encoder + tokenizer and wrap it as a context embedder.

--- a/thenoise/dit/krea2/encoder.py
+++ b/thenoise/dit/krea2/encoder.py
@@ -14,6 +14,7 @@ instead of requiring a separate transformers/Diffusers checkpoint.
 
 import logging
 from dataclasses import dataclass
+from typing import Union
 
 import torch
 from accelerate import init_empty_weights
@@ -120,7 +121,7 @@ def _load_qwen3_vl_model(
     model_path: str,
     *,
     dtype: torch.dtype,
-    device: torch.device | str,
+    device: Union[str, torch.device],
     disable_mmap: bool = True,
 ) -> Qwen3VLForConditionalGeneration:
     """Build Qwen3-VL-4B from the vendored config and load weights from a local safetensors."""
@@ -129,7 +130,7 @@ def _load_qwen3_vl_model(
         model = Qwen3VLForConditionalGeneration._from_config(config)
 
     logger.info(f"Loading Krea 2 text encoder (Qwen3-VL) weights from {model_path}")
-    sd = load_split_weights(model_path, device=str(device), disable_mmap=disable_mmap, dtype=dtype)
+    sd = load_split_weights(model_path, device=device, disable_mmap=disable_mmap, dtype=dtype)
     sd = _convert_comfyui_qwen3vl_state_dict(sd)
 
     info = model.load_state_dict(sd, strict=False, assign=True)
@@ -153,8 +154,8 @@ def _load_qwen3_vl_model(
 def load_qwen3_vl_conditioner(
     model_path: str,
     *,
-    dtype: torch.dtype = torch.bfloat16,
-    device: torch.device | str = "cpu",
+    dtype: torch.dtype,
+    device: Union[str, torch.device],
     max_length: int = TextEncoderConfig.max_length,
     select_layers: tuple[int, ...] = TextEncoderConfig.select_layers,
     tokenizer_repo: str = QWEN3_VL_4B_INSTRUCT_REPO_ID,

--- a/thenoise/dit/krea2/utils.py
+++ b/thenoise/dit/krea2/utils.py
@@ -37,8 +37,8 @@ single_mmdit_large_wide = SingleMMDiTConfig(
 
 def load_krea2_dit(
     dit_path: str,
-    device: Union[str, torch.device] = "cpu",
-    dtype: torch.dtype = torch.bfloat16,
+    device: Union[str, torch.device],
+    dtype: torch.dtype,
     config: SingleMMDiTConfig = single_mmdit_large_wide,
     loading_device: Optional[Union[str, torch.device]] = None,
 ) -> SingleStreamDiT:
@@ -61,8 +61,8 @@ def load_krea2_dit(
 
 def load_krea2_text_encoder(
     path: str,
-    dtype: torch.dtype = torch.bfloat16,
-    device: Union[str, torch.device] = "cpu",
+    dtype: torch.dtype,
+    device: Union[str, torch.device],
     max_length: int = TextEncoderConfig.max_length,
     select_layers: tuple = TextEncoderConfig.select_layers,
     tokenizer_repo: str = QWEN3_VL_4B_INSTRUCT_REPO_ID,

--- a/thenoise/dit/zimage/utils.py
+++ b/thenoise/dit/zimage/utils.py
@@ -81,8 +81,8 @@ ZIMAGE_DIT_CONFIG = dict(
 
 def load_zimage_dit(
     dit_path: str,
-    device: Union[str, torch.device] = "cpu",
-    dtype: torch.dtype = torch.bfloat16,
+    device: Union[str, torch.device],
+    dtype: torch.dtype,
     loading_device: Optional[Union[str, torch.device]] = None,
     config: Optional[dict] = None,
 ) -> ZImageTransformer2DModel:
@@ -115,7 +115,7 @@ def _load_qwen3(
         qwen3 = Qwen3ForCausalLM._from_config(config)
 
     logger.info(f"Loading Z-Image text encoder (Qwen3-4B) weights from {path}")
-    sd = load_split_weights(path, device=str(device), disable_mmap=disable_mmap, dtype=dtype)
+    sd = load_split_weights(path, device=device, disable_mmap=disable_mmap, dtype=dtype)
 
     # Qwen3-4B ties the LM head to the input embeddings (tie_word_embeddings=true), so
     # the checkpoint omits lm_head.weight; re-tie so the strict load passes.

--- a/thenoise/runtime.py
+++ b/thenoise/runtime.py
@@ -14,6 +14,8 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Optional
 
+from thenoise.utils.device import clean_memory_on_device
+
 logger = logging.getLogger(__name__)
 
 
@@ -95,11 +97,7 @@ class Runtime:
         self._model = None
         self._model_name = None
         gc.collect()
-        try:
-            import torch
-            torch.cuda.empty_cache()
-        except Exception:  # torch may be unavailable (config-only tests)
-            pass
+        clean_memory_on_device(self._settings.device)
 
     @property
     def model(self) -> Any:

--- a/thenoise/samplers/euler.py
+++ b/thenoise/samplers/euler.py
@@ -6,6 +6,7 @@ from typing import List
 import torch
 from tqdm import tqdm
 
+from thenoise.utils.device import synchronize_device
 from .base import Sampler, Step
 
 
@@ -30,6 +31,6 @@ class EulerSampler(Sampler):
             v = self.model.denoise_step(x, step.t, cond, guidance_scale, i)
             x = x.float() - step.delta * v.float()
             x = x.to(dtype)
-            # Synchronize to get accurate timing
-            torch.cuda.synchronize()
+            # Synchronize to get accurate timing, on whatever device we're on.
+            synchronize_device(x.device)
         return x

--- a/thenoise/upscale/__init__.py
+++ b/thenoise/upscale/__init__.py
@@ -14,6 +14,7 @@ Usage:
     out = adaptor.from_vae_latent(up)            # raw -> pipeline latent
 """
 from __future__ import annotations
+from typing import Union
 
 import logging
 from pathlib import Path
@@ -66,8 +67,8 @@ def upscale_weight_path(filename: str) -> Path:
 
 def load_latent_upscaler(
     format_name: str,
-    device: str | torch.device = "cuda",
-    dtype: torch.dtype = torch.bfloat16,
+    device: Union[str, torch.device],
+    dtype: torch.dtype,
 ) -> tuple[LatentUpscaler, LatentFormatAdaptor]:
     """Load the latent upscaler for the given ``format_name``.
 
@@ -101,7 +102,7 @@ def load_latent_upscaler(
     return model, adaptor
 
 
-def load_pixel_upscaler(path: str, device: str = "cuda") -> tuple:
+def load_pixel_upscaler(path: str, device: str) -> tuple:
     """Load a pixel-domain upscaler from a safetensors file.
 
     Generic entry point so the model-facing code never names a specific pixel

--- a/thenoise/upscale/esrgan.py
+++ b/thenoise/upscale/esrgan.py
@@ -38,6 +38,7 @@ Original copyright/license notice follows.
 # Copyright (c) 2021 xinntao. Licensed under the BSD-3-Clause License.
 # Source: https://github.com/xinntao/Real-ESRGAN
 from __future__ import annotations
+from typing import Union
 
 import re
 
@@ -288,7 +289,7 @@ def _remap_original_esrgan(state: dict) -> dict:
     return out
 
 
-def load_esrgan(path: str, device: str = "cuda") -> tuple[RRDBNet, int]:
+def load_esrgan(path: str, device: Union[str, torch.device]) -> tuple[RRDBNet, int]:
     """Load a Real-ESRGAN model from a safetensors file.
 
     Supports both the ComfyUI repackaged naming (``body.*`` / ``conv_first``)

--- a/thenoise/upscale/pixel.py
+++ b/thenoise/upscale/pixel.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 import torch
 
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 class PixelUpscalerManager:
     """Owns the pixel-domain upscaler pool: dir, scales, last-used loaded model."""
 
-    def __init__(self, upscaler_dir: str = "", device: str = "cuda"):
+    def __init__(self, upscaler_dir: str, device: Union[str, torch.device]):
         self.upscaler_dir = upscaler_dir
         self.device = device
         self._pixel_upscaler = None

--- a/thenoise/utils/device.py
+++ b/thenoise/utils/device.py
@@ -1,0 +1,27 @@
+"""Device helpers that are agnostic to the active backend (CUDA/ROCm, XPU, MPS)."""
+from typing import Optional, Union
+import torch
+
+def clean_memory_on_device(device: Optional[Union[str, torch.device]]):
+    if device is None:
+        return
+    if isinstance(device, str):
+        device = torch.device(device)
+    if device.type == "cuda":
+        torch.cuda.empty_cache()
+    elif device.type == "cpu":
+        pass
+    elif device.type == "mps":  # not tested
+        torch.mps.empty_cache()
+
+def synchronize_device(device: Optional[Union[str, torch.device]]):
+    if device is None:
+        return
+    if isinstance(device, str):
+        device = torch.device(device)
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+    elif device.type == "xpu":
+        torch.xpu.synchronize()
+    elif device.type == "mps":
+        torch.mps.synchronize()

--- a/thenoise/utils/safetensors.py
+++ b/thenoise/utils/safetensors.py
@@ -9,6 +9,7 @@ from typing import Dict, Any, Union, Optional
 from safetensors.torch import load_file
 
 from thenoise.utils.setup_logging import setup_logging
+from thenoise.utils.device import synchronize_device
 
 setup_logging()
 import logging
@@ -75,7 +76,7 @@ class MemoryEfficientSafeOpen:
 
         **Note:**
         If device is 'cuda' , the transfer to GPU is done efficiently using pinned memory and non-blocking transfer.
-        So you must ensure that the transfer is completed before using the tensor (e.g., by `torch.cuda.synchronize()`).
+        So you must ensure that the transfer is completed before using the tensor.
 
         If the tensor is large (>10MB) and the target device is CUDA, memory mapping with numpy.memmap is used to avoid intermediate copies.
 
@@ -290,8 +291,7 @@ def load_safetensors(
         with MemoryEfficientSafeOpen(path, disable_numpy_memmap=disable_numpy_memmap) as f:
             for key in f.keys():
                 state_dict[key] = f.get_tensor(key, device=device, dtype=dtype)
-            if device is not None and device.type == "cuda":
-                torch.cuda.synchronize()
+            synchronize_device(device)
         return state_dict
     else:
         try:
@@ -328,7 +328,7 @@ def get_split_weight_filenames(file_path: str) -> Optional[list[str]]:
 
 
 def load_split_weights(
-    file_path: str, device: Union[str, torch.device] = "cpu", disable_mmap: bool = False, dtype: Optional[torch.dtype] = None
+    file_path: str, device: Union[str, torch.device], disable_mmap: bool = False, dtype: Optional[torch.dtype] = None
 ) -> Dict[str, torch.Tensor]:
     """
     Load split weights from a file. If the file name ends with 00001-of-00004 etc, it will load all files with the same prefix.

--- a/thenoise/vae/flux.py
+++ b/thenoise/vae/flux.py
@@ -183,7 +183,7 @@ class AutoencoderKLFlux(nn.Module):
 
 def load_flux_vae(
     vae_path: str,
-    device: Union[str, torch.device] = "cpu",
+    device: Union[str, torch.device],
     disable_mmap: bool = False,
     dtype: Optional[torch.dtype] = None,
 ) -> AutoencoderKLFlux:

--- a/thenoise/vae/flux2.py
+++ b/thenoise/vae/flux2.py
@@ -222,7 +222,7 @@ class AutoencoderKLFlux2(nn.Module):
 
 def load_flux2_vae(
     vae_path: str,
-    device: Union[str, torch.device] = "cpu",
+    device: Union[str, torch.device],
     disable_mmap: bool = False,
     dtype: Optional[torch.dtype] = None,
 ) -> AutoencoderKLFlux2:

--- a/thenoise/vae/qwen_image.py
+++ b/thenoise/vae/qwen_image.py
@@ -826,8 +826,8 @@ def convert_comfyui_state_dict(sd):
 
 def load_qwen_vae(
     vae_path: str,
+    device: Union[str, torch.device],
     input_channels: int = 3,
-    device: Union[str, torch.device] = "cpu",
     disable_mmap: bool = False,
 ) -> AutoencoderKLQwenImage:
     """Load the Qwen-Image VAE from a given path."""


### PR DESCRIPTION
Avoid having default dtypes/devices to make sure these are always explicitly set. Additionally, add back generic cache-clearing/synchronization utilities