### PR TITLE
Add offload device

### DIFF
--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,138 @@
+"""MemoryManager tests (no GPU).
+
+The manager's real device moves are exercised with cpu (load) and meta (offload)
+for the directions torch supports. The ``ensure``-loads-an-offloaded-component path
+(offload -> load) is tested with a recording mock, since a real ``meta -> cpu``
+move cannot carry data.
+"""
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from thenoise.memory import MemoryManager
+
+
+class _Comp(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.p = nn.Parameter(torch.zeros(4, 4))
+
+
+class _MockComp:
+    """Records ``.to(device)`` calls; no real parameters (device = None)."""
+
+    def __init__(self):
+        self.to_calls = []
+
+    def to(self, device):
+        self.to_calls.append(str(torch.device(device)))
+        return self
+
+    def parameters(self):
+        return iter(())
+
+    def buffers(self):
+        return iter(())
+
+
+class _WrapperComp:
+    """Mimics a wrapper embedder: exposes ``.device``/``.to`` over a real module."""
+
+    def __init__(self, device):
+        self._model = _Comp().to(device)
+        self.to_calls = []
+
+    @property
+    def device(self):
+        return next(self._model.parameters()).device
+
+    def to(self, device):
+        self.to_calls.append(str(torch.device(device)))
+        self._model.to(device)
+        return self
+
+    def parameters(self):
+        return iter(())
+
+
+def _dev(m):
+    return next(m.parameters()).device
+
+
+# ------------------------------------------------------------ resident mode
+def test_resident_mode_is_noop():
+    m = _Comp()
+    mm = MemoryManager("cpu", "cpu")  # offload == load -> no moves
+    assert not mm.offloads
+    mm.register("comp", m)
+    mm.ensure("comp")
+    assert "comp" in mm.resident()
+    mm.offload("comp")
+    # Resident mode: offload is a no-op, the component stays on the load device.
+    assert _dev(m) == torch.device("cpu")
+    assert "comp" in mm.resident()
+
+
+# ------------------------------------------------------------ offload mode
+def test_register_tracks_initial_residency():
+    on_cpu = _Comp()
+    on_meta = _Comp().to("meta")  # cpu -> meta is supported
+    mm = MemoryManager("cpu", "meta")
+    mm.register("a", on_cpu)
+    mm.register("b", on_meta)
+    assert "a" in mm.resident()
+    assert "b" not in mm.resident()
+
+
+def test_ensure_loads_offloaded_component():
+    m = _MockComp()
+    mm = MemoryManager("cpu", "meta")
+    mm.register("comp", m)  # no params -> not resident
+    assert "comp" not in mm.resident()
+    mm.ensure("comp")
+    assert m.to_calls == ["cpu"]
+    assert "comp" in mm.resident()
+
+
+def test_ensure_is_idempotent():
+    m = _MockComp()
+    mm = MemoryManager("cpu", "meta")
+    mm.register("comp", m)
+    mm.ensure("comp")
+    mm.ensure("comp")
+    assert m.to_calls == ["cpu"]  # only one move
+
+
+def test_offload_moves_to_offload_device():
+    m = _MockComp()
+    mm = MemoryManager("cpu", "meta")
+    mm.register("comp", m)
+    mm.ensure("comp")
+    mm.offload("comp")
+    assert m.to_calls == ["cpu", "meta"]
+    assert "comp" not in mm.resident()
+
+
+def test_missing_component_is_noop():
+    mm = MemoryManager("cpu", "meta")
+    mm.ensure("nope")
+    mm.offload("nope")
+    assert mm.resident() == set()
+
+
+# ------------------------------------------------------- wrappers (embedders)
+def test_wrapper_component_tracks_residency():
+    w = _WrapperComp("cpu")
+    mm = MemoryManager("cpu", "meta")
+    mm.register("te", w)
+    assert "te" in mm.resident()
+
+
+def test_wrapper_offload_moves_model():
+    w = _WrapperComp("cpu")
+    mm = MemoryManager("cpu", "meta")
+    mm.register("te", w)
+    mm.offload("te")
+    assert w.device == torch.device("meta")
+    assert "te" not in mm.resident()

--- a/tests/test_zimage.py
+++ b/tests/test_zimage.py
@@ -42,7 +42,7 @@ def test_text_encoder_rejects_non_safetensors(tmp_path):
     p = tmp_path / "text_encoder"
     p.mkdir()
     try:
-        load_zimage_text_encoder(str(p), device="cpu")
+        load_zimage_text_encoder(str(p), device="cpu", dtype=torch.bfloat16)
     except ValueError as e:
         assert ".safetensors" in str(e)
     else:

--- a/thenoise/__main__.py
+++ b/thenoise/__main__.py
@@ -8,7 +8,7 @@ def _serve(args) -> None:
     from .runtime import Settings, ModelPaths, Runtime
     settings = Settings(
         device=args.device, host=args.host, port=args.port,
-        upscaler_dir=args.upscaler_dir,
+        upscaler_dir=args.upscaler_dir, offload_device=args.offload_device,
     )
 
     runtime = Runtime(settings)

--- a/thenoise/cli.py
+++ b/thenoise/cli.py
@@ -102,6 +102,8 @@ def build_parser() -> argparse.ArgumentParser:
                        help="bind port (default: 8000)")
     serve.add_argument("--device", default="cuda",
                        help="inference device; ROCm aliases cuda -> hip (default: cuda)")
+    serve.add_argument("--offload-device", default="",
+                       help="device for idle weights (default: auto-detect from safetensors size vs VRAM)")
 
     # generate
     gen = sub.add_parser("generate", help="run one generation and save a PNG")

--- a/thenoise/dit/flux2/utils.py
+++ b/thenoise/dit/flux2/utils.py
@@ -155,7 +155,16 @@ class Qwen3Embedder:
         self.tokenizer = tokenizer
         self.model = model
         self.max_length = MAX_LENGTH
-        self.device = next(model.parameters()).device
+
+    @property
+    def device(self):
+        """The embedder's model device (follows the model when it is moved)."""
+        return next(self.model.parameters()).device
+
+    def to(self, device):
+        """Forward placement to the wrapped model (so the memory manager can move it)."""
+        self.model.to(device)
+        return self
 
     def __call__(self, prompt: str) -> torch.Tensor:
         messages = [{"role": "user", "content": prompt}]
@@ -169,8 +178,9 @@ class Qwen3Embedder:
             truncation=True,
             max_length=self.max_length,
         )
-        input_ids = inputs.input_ids.to(self.device)
-        attention_mask = inputs.attention_mask.to(self.device)
+        device = self.device
+        input_ids = inputs.input_ids.to(device)
+        attention_mask = inputs.attention_mask.to(device)
         with torch.no_grad():
             output = self.model(
                 input_ids=input_ids,

--- a/thenoise/dit/zimage/utils.py
+++ b/thenoise/dit/zimage/utils.py
@@ -119,8 +119,8 @@ def _load_qwen3(
 
 def load_zimage_text_encoder(
     path: str,
-    dtype: torch.dtype = torch.bfloat16,
-    device: Union[str, torch.device] = "cpu",
+    dtype: torch.dtype,
+    device: Union[str, torch.device],
     tokenizer_dir: Optional[str] = None,
 ) -> tuple:
     """Load the Z-Image Qwen3 text encoder + tokenizer.

--- a/thenoise/memory.py
+++ b/thenoise/memory.py
@@ -1,0 +1,130 @@
+"""Device placement / residency manager for a model's swappable components.
+
+A ``DiffusionModel`` owns exactly one ``MemoryManager``. Each heavy component
+(the DiT, the text encoder) is *registered* with it; the pipeline controller
+``ensure``s the components the current stage needs and ``offload``s the rest, so
+on a dGPU (dedicated VRAM separated from system RAM) only the weights in active
+use are resident on the compute device at any time.
+
+The manager is a strict single-transition state machine per request: a component is
+ensured (moved to the load device) and later offloaded (moved back) at
+statically-known stage boundaries. There is no LRU and no keep-resident hint.
+
+When ``offload_device == load_device`` (resident mode — e.g. an iGPU with enough
+unified memory to fit every component) every move is a no-op, so a system that
+can hold all weights never pays any transfer cost.
+
+Only *weights / parameters* are managed here. Intermediate activations (latents,
+conditioning, pixels) are owned by the pipeline cache and stay on the compute
+device.
+"""
+from __future__ import annotations
+
+from typing import Dict, Optional, Set, Union
+
+import torch
+from torch import nn
+
+from thenoise.utils.device import clean_memory_on_device
+
+
+class MemoryManager:
+    """Placement + residency for a model's swappable components."""
+
+    def __init__(
+        self,
+        load_device: Union[str, torch.device],
+        offload_device: Union[str, torch.device],
+    ):
+        self._load = torch.device(load_device)
+        self._offload = torch.device(offload_device)
+        self._components: Dict[str, Optional[nn.Module]] = {}
+        self._resident: Set[str] = set()
+
+    # ------------------------------------------------------------- identity
+    @property
+    def load_device(self) -> torch.device:
+        """The compute device components run on."""
+        return self._load
+
+    @property
+    def offload_device(self) -> torch.device:
+        """The device idle weights live on."""
+        return self._offload
+
+    @property
+    def offloads(self) -> bool:
+        """True when offloading actually moves anything (the devices differ)."""
+        return self._load != self._offload
+
+    # ----------------------------------------------------------- registry
+    def register(self, name: str, module: Optional[nn.Module]) -> None:
+        """Register ``module`` under ``name``, noting its initial residency.
+
+        A module already on the load device (e.g. the always-resident VAE) is
+        recorded as resident; a module on the offload device is not.
+        """
+        self._components[name] = module
+        if module is not None and self._module_device(module) == self._load:
+            self._resident.add(name)
+
+    def resident(self) -> Set[str]:
+        """Names of components currently resident on the load device."""
+        return set(self._resident)
+
+    # ------------------------------------------------------------ placement
+    def ensure(self, *names: str) -> None:
+        """Move each named component to the load device (no-op if already there)."""
+        for name in names:
+            if name in self._resident:
+                continue
+            module = self._components.get(name)
+            if module is None:
+                continue
+            module.to(self._load)
+            self._resident.add(name)
+
+    def offload(self, *names: str) -> None:
+        """Move each named component to the offload device and free compute memory.
+
+        In resident mode (``offload_device == load_device``) this is a no-op that
+        simply marks the components resident, so a machine with enough memory never
+        moves anything.
+        """
+        if self._load == self._offload:
+            self._resident.update(names)
+            return
+        for name in names:
+            if name not in self._resident:
+                continue
+            module = self._components.get(name)
+            if module is None:
+                continue
+            module.to(self._offload)
+            self._resident.discard(name)
+        clean_memory_on_device(self._load)
+
+    def offload_all(self) -> None:
+        """Offload every registered component (use with care: includes the VAE)."""
+        self.offload(*self._components)
+
+    # ------------------------------------------------------------- helpers
+    @staticmethod
+    def _module_device(module: nn.Module) -> Optional[torch.device]:
+        """Current device of ``module`` (an ``nn.Module`` or a wrapper).
+
+        Wrappers such as FluxKlein's ``Qwen3Embedder`` expose a ``device``
+        attribute/property; plain modules are probed via their first parameter or
+        buffer."""
+        if hasattr(module, "device"):
+            return module.device
+        for p in module.parameters():
+            if p is not None:
+                return p.device
+        for b in module.buffers():
+            if b is not None:
+                return b.device
+        return None
+
+
+__all__ = ["MemoryManager"]

--- a/thenoise/models/anima.py
+++ b/thenoise/models/anima.py
@@ -58,9 +58,9 @@ class AnimaModel(DiffusionModel):
 
         logger.info("Loading Anima DiT from %s", config.dit_path)
         self.dit = anima_utils.load_anima_model(
-            config.device,
+            self.offload_device,
             config.dit_path,
-            loading_device=config.device,
+            loading_device=self.offload_device,
             dit_weight_dtype=config.dtype,
         )
         self.dit.eval().requires_grad_(False)
@@ -68,7 +68,7 @@ class AnimaModel(DiffusionModel):
         # Text encoder (Qwen3-0.6B) + tokenizers.
         logger.info("Loading Anima text encoder from %s", config.text_encoder_path)
         self.text_encoder, self.qwen3_tokenizer = anima_utils.load_qwen3_text_encoder(
-            config.text_encoder_path, dtype=config.dtype, device=config.device
+            config.text_encoder_path, dtype=config.dtype, device=self.offload_device
         )
         self.text_encoder.eval().requires_grad_(False)
         self.t5_tokenizer = anima_utils.load_t5_tokenizer(None)
@@ -90,6 +90,11 @@ class AnimaModel(DiffusionModel):
             .requires_grad_(False)
         )
 
+        # Register swappable components with the memory manager.
+        self.memory.register("dit", self.dit)
+        self.memory.register("text_encoder", self.text_encoder)
+        self.memory.register("vae", self.vae)
+
         logger.info("Anima model ready on %s (%s)", config.device, config.dtype)
 
     # ------------------------------------------------------------ kernels
@@ -97,27 +102,46 @@ class AnimaModel(DiffusionModel):
         self,
         args: EncodePromptArgs,
     ) -> Conditioning:
-        cond = self._encode_prompt(args.prompt)
-        null = None
-        if args.guidance_scale > 1.0:
-            null = self._encode_prompt(args.negative_prompt)
-        return Conditioning(cond=cond, null=null)
-
-    def _encode_prompt(self, prompt: str) -> torch.Tensor:
-        """Tokenize -> Qwen3 encode -> LLM-adapter cross-attention embedding (bf16)."""
+        """Text-encoder only: RAW Qwen3/T5 embeddings (DiT fusion in ``fuse_text``)."""
         dev = torch.device(self.device)
         with torch.no_grad():
-            tokens = self.tokenize_strategy.tokenize(prompt)
-            # [prompt_embeds, qwen3_mask, t5_ids, t5_mask]
-            embed = self.encoding_strategy.encode_tokens(self.tokenize_strategy, [self.text_encoder], tokens)
-            crossattn_emb = self.dit._preprocess_text_embeds(
-                source_hidden_states=embed[0].to(dev),
-                target_input_ids=embed[2].to(dev),
-                target_attention_mask=embed[3].to(dev),
-                source_attention_mask=embed[1].to(dev),
+            cond = self._encode_raw(args.prompt, dev)
+            null = (
+                self._encode_raw(args.negative_prompt, dev)
+                if args.guidance_scale > 1.0
+                else None
             )
-            crossattn_emb[~embed[3].bool()] = 0
-            return crossattn_emb.to(torch.bfloat16)
+        return Conditioning(cond=cond, null=null)
+
+    def _encode_raw(self, prompt: str, dev: torch.device):
+        """Tokenize -> Qwen3 encode -> raw LLM-adapter input bundle (text_encoder only).
+
+        Returns ``[prompt_embeds, qwen3_mask, t5_ids, t5_mask]``; the DiT
+        consumes it in ``fuse_text`` (which runs with the DiT resident).
+        """
+        tokens = self.tokenize_strategy.tokenize(prompt)
+        return self.encoding_strategy.encode_tokens(
+            self.tokenize_strategy, [self.text_encoder], tokens
+        )
+
+    def fuse_text(self, cond: Conditioning) -> Conditioning:
+        """DiT-side fusion: raw embeddings -> LLM-adapter cross-attention conditioning."""
+        dev = torch.device(self.device)
+        with torch.no_grad():
+            fused = self._fuse_raw(cond.cond, dev)
+            null = self._fuse_raw(cond.null, dev) if cond.null is not None else None
+        return Conditioning(cond=fused, null=null)
+
+    def _fuse_raw(self, embed, dev: torch.device) -> torch.Tensor:
+        """DiT LLM-adapter cross-attention embedding (bf16)."""
+        crossattn_emb = self.dit._preprocess_text_embeds(
+            source_hidden_states=embed[0].to(dev),
+            target_input_ids=embed[2].to(dev),
+            target_attention_mask=embed[3].to(dev),
+            source_attention_mask=embed[1].to(dev),
+        )
+        crossattn_emb[~embed[3].bool()] = 0
+        return crossattn_emb.to(torch.bfloat16)
 
     def init_latents(self, params: SamplingParams) -> torch.Tensor:
         dev = torch.device(self.device)

--- a/thenoise/models/base.py
+++ b/thenoise/models/base.py
@@ -58,6 +58,7 @@ from safetensors.torch import load_file
 
 from thenoise.memory import MemoryManager
 from thenoise.models.config import EncodePromptArgs, ModelConfig, SamplingParams
+from thenoise.utils.device import get_device_memory
 from thenoise.samplers import Step
 from thenoise.upscale import load_latent_upscaler
 
@@ -73,6 +74,13 @@ from thenoise.utils.lora import LoRAApplyResult
 from thenoise.utils.safetensors import WRAP_PREFIXES
 
 logger = logging.getLogger(__name__)
+
+# Fraction of the compute device's VRAM that the resident *weights* (DiT + text
+# encoder + VAE) may occupy while staying resident (``offload == load``, no moves).
+# The remaining fraction is deliberately conservative headroom for the activation peak
+# (denoise, and especially VAE decode at upscaled resolutions) plus the pipeline
+# cache. This is a conservative value. The offload device can be forced via --offload-device
+_RESIDENT_VRAM_FRACTION = 0.6
 
 
 @dataclass
@@ -173,20 +181,18 @@ class DiffusionModel(ABC):
 
         The expected resident bytes are estimated from the combined sizes of the three
         checkpoint files (not 100%% accurate, close enough). If they fit the compute
-        device's VRAM with room left over for activations we stay resident
-        (``offload == load`` -> no moves); otherwise we offload to CPU.
+        device's VRAM with ``_RESIDENT_VRAM_FRACTION`` headroom left over for
+        activations we stay resident (``offload == load`` -> no moves); otherwise
+        we offload to CPU.
         """
-        try:
-            total_vram = torch.cuda.get_device_properties(config.device).total_memory
-        except Exception:
+        total_vram = get_device_memory(config.device)
+        if total_vram is None:
             return config.device
         resident = sum(
             self._file_size(p)
             for p in (config.dit_path, config.vae_path, config.text_encoder_path)
         )
-        # Weights must leave room for activations (denoise/decode peaks). 0.55 is
-        # deliberately conservative: resident weights <= ~55%% of VRAM -> keep resident.
-        if resident <= 0.55 * total_vram:
+        if resident <= _RESIDENT_VRAM_FRACTION * total_vram:
             return config.device
         return "cpu"
 

--- a/thenoise/models/base.py
+++ b/thenoise/models/base.py
@@ -48,13 +48,15 @@ ones. This avoids reloading the entire model from disk.
 from __future__ import annotations
 
 import logging
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import torch
 from safetensors.torch import load_file
 
+from thenoise.memory import MemoryManager
 from thenoise.models.config import EncodePromptArgs, ModelConfig, SamplingParams
 from thenoise.samplers import Step
 from thenoise.upscale import load_latent_upscaler
@@ -142,11 +144,16 @@ class DiffusionModel(ABC):
 
     def __init__(self, *, config: ModelConfig):
         self.device = config.device
+        self.offload_device = config.offload_device or self._detect_offload_device(config)
         self.dtype = config.dtype
         self.dit_path = config.dit_path
         self.vae_path = config.vae_path
         self.text_encoder_path = config.text_encoder_path
         self.lora_dir = config.lora_dir
+
+        # Component placement: subclasses register ``dit`` / ``text_encoder`` /
+        # ``vae``; the pipeline controller ensures/offloads them by name.
+        self.memory = MemoryManager(self.device, self.offload_device)
 
         torch._dynamo.config.recompile_limit = 64
 
@@ -160,16 +167,60 @@ class DiffusionModel(ABC):
         self._upscaler = None
         self._adaptor = None
 
+    # ------------------------------------------------------------ devices
+    def _detect_offload_device(self, config: ModelConfig) -> str:
+        """Pick an offload device from safetensors size vs VRAM (or ``device``).
+
+        The expected resident bytes are estimated from the combined sizes of the three
+        checkpoint files (not 100%% accurate, close enough). If they fit the compute
+        device's VRAM with room left over for activations we stay resident
+        (``offload == load`` -> no moves); otherwise we offload to CPU.
+        """
+        try:
+            total_vram = torch.cuda.get_device_properties(config.device).total_memory
+        except Exception:
+            return config.device
+        resident = sum(
+            self._file_size(p)
+            for p in (config.dit_path, config.vae_path, config.text_encoder_path)
+        )
+        # Weights must leave room for activations (denoise/decode peaks). 0.55 is
+        # deliberately conservative: resident weights <= ~55%% of VRAM -> keep resident.
+        if resident <= 0.55 * total_vram:
+            return config.device
+        return "cpu"
+
+    @staticmethod
+    def _file_size(path: str) -> int:
+        try:
+            return os.path.getsize(path)
+        except OSError:
+            return 0
+
     # ------------------------------------------------------------------ hooks
     @abstractmethod
-    def encode_prompt(self, args: EncodePromptArgs) -> Conditioning:
-        """Tokenize + encode prompt (and negative) into conditioning.
+    def encode_prompt(self, args: EncodePromptArgs) -> "Conditioning":
+        """Tokenize + encode prompt (and negative) into RAW conditioning.
 
-        Accepts a single ``EncodePromptArgs`` struct (prompt, negative_prompt,
-        guidance_scale, image) so new knobs never change the signature. ``image``
-        is only set in the edit path (``supports_edit`` models); multimodal
-        encoders feed it as vision tokens in addition to any reference latent.
+        Text-encoder only (the DiT is NOT needed here). Accepts a single
+        ``EncodePromptArgs`` struct (prompt, negative_prompt, guidance_scale,
+        image) so new knobs never change the signature. ``image`` is only set in
+        the edit path (``supports_edit`` models); multimodal encoders feed it as
+        vision tokens in addition to any reference latent. Returns the raw
+        conditioning, transformed into the model-internal conditioning by
+        ``fuse_text`` (which runs with the DiT resident).
         """
+
+    def fuse_text(self, cond: "Conditioning") -> "Conditioning":
+        """DiT-side text fusion: raw conditioning -> model-internal conditioning.
+
+        Runs with the DiT resident (inside the dit block), after the text encoder
+        has been offloaded. Default is the identity for models whose prompt
+        conditioning is already the final form (e.g. FluxKlein, ZImage); models
+        that fuse the text stream through the DiT (Anima's
+        ``_preprocess_text_embeds``, Krea2's ``fuse_text``) override it.
+        """
+        return cond
 
     @abstractmethod
     def init_latents(self, params: SamplingParams) -> torch.Tensor:

--- a/thenoise/models/config.py
+++ b/thenoise/models/config.py
@@ -33,6 +33,7 @@ class ModelConfig:
     vae_path: str
     text_encoder_path: str
     device: str = "cuda"
+    offload_device: str = ""  # empty = auto-detect from safetensors size vs VRAM
     dtype: torch.dtype = torch.bfloat16
     lora_dir: Optional[str] = None  # LoRAs mutate the DiT weights -> model concern
 

--- a/thenoise/models/flux_klein.py
+++ b/thenoise/models/flux_klein.py
@@ -82,7 +82,7 @@ class FluxKleinModel(DiffusionModel):
         self.params: Flux2Params = detect_klein_params(config.dit_path)
         self.is_8b = self.params.context_in_dim == 12288
         logger.info("Loading Flux Klein DiT (%s) from %s", self.variant_label, config.dit_path)
-        self.dit = load_flux2_dit(config.dit_path, self.params, device=config.device, dtype=config.dtype)
+        self.dit = load_flux2_dit(config.dit_path, self.params, device=self.offload_device, dtype=config.dtype)
         self.dit.eval().requires_grad_(False)
 
         logger.info("Loading Flux Klein text encoder (Qwen3-%s) from %s", self.text_label, config.text_encoder_path)
@@ -90,13 +90,18 @@ class FluxKleinModel(DiffusionModel):
             config.text_encoder_path,
             is_8b=self.is_8b,
             dtype=config.dtype,
-            device=config.device,
+            device=self.offload_device,
             tokenizer_dir=find_flux2_tokenizer_dir(config.text_encoder_path),
         )
 
         # Flux.2 VAE (encoder + decoder).
         self.vae = load_flux2_vae(self.vae_path, device=self.device, disable_mmap=True, dtype=self.dtype)
         self.vae.eval().requires_grad_(False)
+
+        # Register swappable components with the memory manager.
+        self.memory.register("dit", self.dit)
+        self.memory.register("text_encoder", self.text_encoder)
+        self.memory.register("vae", self.vae)
 
         logger.info("Flux Klein model (%s) ready on %s (%s)", self.variant_label, config.device, config.dtype)
 

--- a/thenoise/models/krea2.py
+++ b/thenoise/models/krea2.py
@@ -63,7 +63,7 @@ class Krea2Model(DiffusionModel):
         logger.info("Loading Krea 2 DiT from %s", config.dit_path)
         self.dit = krea2_utils.load_krea2_dit(
             config.dit_path,
-            device=config.device,
+            device=self.offload_device,
             dtype=config.dtype,
         )
         self.dit.eval().requires_grad_(False)
@@ -72,7 +72,7 @@ class Krea2Model(DiffusionModel):
         self.encoder = krea2_utils.load_krea2_text_encoder(
             config.text_encoder_path,
             dtype=config.dtype,
-            device=config.device,
+            device=self.offload_device,
             tokenizer_dir=krea2_utils.find_krea2_tokenizer_dir(config.text_encoder_path),
         )
 
@@ -87,6 +87,11 @@ class Krea2Model(DiffusionModel):
         # VAE latent geometry (shared Qwen-Image VAE): 8x spatial compression.
         self._compression = self.vae.compression
 
+        # Register swappable components with the memory manager.
+        self.memory.register("dit", self.dit)
+        self.memory.register("text_encoder", self.encoder)
+        self.memory.register("vae", self.vae)
+
         logger.info("Krea 2 model ready on %s (%s)", config.device, config.dtype)
 
     # ------------------------------------------------------------ kernels
@@ -94,31 +99,40 @@ class Krea2Model(DiffusionModel):
         self,
         args: EncodePromptArgs,
     ) -> Conditioning:
+        """Text-encoder only: RAW prompt embeddings (DiT fusion in ``fuse_text``)."""
         cfg = args.guidance_scale > 1.0
         txt, txtmask, untxt, untxtmask = encode_prompts(
             self.encoder, [args.prompt], [args.negative_prompt], cfg=cfg
         )
-        # Fuse the text stream ONCE here (prompt stage) so it is cached and reused
-        # across denoise steps and across runs with the same prompt/LoRA config. The
-        # fusion is independent of image/timestep, but depends on the (LoRA-adjusted)
-        # DiT weights
+        return Conditioning(
+            cond=txt, cond_mask=txtmask, null=untxt, null_mask=untxtmask
+        )
+
+    def fuse_text(self, cond: Conditioning) -> Conditioning:
+        """DiT text fusion: raw embeddings -> cross-attention conditioning.
+
+        Runs ONCE here (inside the dit block, DiT resident) so it is cached and
+        reused across denoise steps. Fusion is independent of image/timestep, but
+        depends on the (LoRA-adjusted) DiT weights, so it runs after
+        ``switch_loras``.
+        """
         dev = torch.device(self.device)
         with torch.no_grad():
             txt_fused = self.dit.fuse_text(
-                txt.to(device=dev, dtype=self.dtype),
-                txtmask.to(device=dev),
+                cond.cond.to(device=dev, dtype=self.dtype),
+                cond.cond_mask.to(device=dev),
             )
             untxt_fused = None
-            if cfg:
+            if cond.null is not None:
                 untxt_fused = self.dit.fuse_text(
-                    untxt.to(device=dev, dtype=self.dtype),
-                    untxtmask.to(device=dev),
+                    cond.null.to(device=dev, dtype=self.dtype),
+                    cond.null_mask.to(device=dev),
                 )
         return Conditioning(
             cond=txt_fused,
-            cond_mask=txtmask,
+            cond_mask=cond.cond_mask,
             null=untxt_fused,
-            null_mask=untxtmask,
+            null_mask=cond.null_mask,
         )
 
     def init_latents(self, params: SamplingParams) -> torch.Tensor:

--- a/thenoise/models/zimage.py
+++ b/thenoise/models/zimage.py
@@ -67,14 +67,14 @@ class ZImageModel(DiffusionModel):
         super().__init__(config=config)
 
         logger.info("Loading Z-Image DiT from %s", config.dit_path)
-        self.dit = load_zimage_dit(config.dit_path, device=config.device, dtype=config.dtype)
+        self.dit = load_zimage_dit(config.dit_path, device=self.offload_device, dtype=config.dtype)
         self.dit.eval().requires_grad_(False)
 
         logger.info("Loading Z-Image text encoder from %s", config.text_encoder_path)
         self.text_encoder, self.tokenizer = load_zimage_text_encoder(
             config.text_encoder_path,
             dtype=config.dtype,
-            device=config.device,
+            device=self.offload_device,
             tokenizer_dir=find_zimage_tokenizer_dir(config.text_encoder_path),
         )
         self.text_encoder.eval().requires_grad_(False)
@@ -82,6 +82,11 @@ class ZImageModel(DiffusionModel):
         # Flux VAE (decoder-only).
         self.vae = load_flux_vae(self.vae_path, device=self.device, disable_mmap=True, dtype=self.dtype)
         self.vae.eval().requires_grad_(False)
+
+        # Register swappable components with the memory manager.
+        self.memory.register("dit", self.dit)
+        self.memory.register("text_encoder", self.text_encoder)
+        self.memory.register("vae", self.vae)
 
         logger.info("Z-Image model ready on %s (%s)", config.device, config.dtype)
 

--- a/thenoise/pipeline.py
+++ b/thenoise/pipeline.py
@@ -293,9 +293,10 @@ class PipelineController:
         decode_key = self._cache_key_decode(sampling_key, r.refined)
 
         with self._lock:
-            model.switch_loras(request.lora_specs, model.dit)
+            memory = model.memory
 
             # Stage 0: reference (image) latent — deterministic per image (edit).
+            # Uses the always-resident VAE.
             ref_latents: Optional[list[torch.Tensor]] = None
             if is_edit:
                 if self._cache.reference_hit(ref_key):
@@ -310,11 +311,12 @@ class PipelineController:
                         ref_latents.append(model.encode_reference(pixels))  # [1,C,H,W]
                     self._cache.reference_store(ref_key, ref_latents)
 
-            # Stage 1: prompt conditioning (image-aware for multimodal encoders).
+            # Stage 1: prompt conditioning — text encoder only (RAW).
             if self._cache.prompt_hit(prompt_key):
                 cond = self._cache.prompt_get()
             else:
-                cond = model.encode_prompt(
+                memory.ensure("text_encoder")
+                cond_raw = model.encode_prompt(
                     EncodePromptArgs(
                         prompt=request.prompt,
                         negative_prompt=request.negative_prompt,
@@ -322,17 +324,24 @@ class PipelineController:
                         image=request.image if is_edit else None,
                     )
                 )
-                self._cache.prompt_store(prompt_key, cond)
+                memory.offload("text_encoder")
 
             params = SamplingParams(
                 height=r.height, width=r.width, steps=r.steps, seed=r.seed,
                 guidance_scale=r.guidance_scale, sampler=r.effective_sampler,
             )
 
-            # Stage 2: sampling (denoise) — ref-conditioned only in the edit path.
+            # Stage 2: sampling — the dit block. The DiT is resident here, so
+            # LoRA switching (which may requantize) and text fusion run in it too.
+            # ``ref_latents``/``ref_method`` are only set in the edit path.
             if self._cache.sampling_hit(sampling_key):
                 latents = self._cache.sampling_get()
             else:
+                memory.ensure("dit")
+                model.switch_loras(request.lora_specs, model.dit)
+                if not self._cache.prompt_hit(prompt_key):
+                    cond = model.fuse_text(cond_raw)
+                    self._cache.prompt_store(prompt_key, cond)
                 with torch.no_grad():
                     latents = self._denoise(
                         cond, params, ref_latents, ref_method or "index"
@@ -340,14 +349,22 @@ class PipelineController:
                 self._cache.sampling_store(sampling_key, latents)
 
             # Stage 3/4: upscale + decode (interleaved so cache hits skip upscale).
+            # The DiT is offloaded before the VAE decode so decode's peak (VAE +
+            # decode activations) does not also carry the DiT weights.
             if self._cache.decode_hit(decode_key):
                 pixels = self._cache.decode_get()
             else:
                 if r.refined:
+                    memory.ensure("dit")
                     latents = self._upscale_and_refine(latents, cond, params)
+                memory.offload("dit")
+                memory.ensure("vae")
                 pixels = model.decode(latents)  # fp32 GPU tensor [C,H,W]
                 self._cache.decode_store(decode_key, pixels)
 
+            # Leave every swappable component offloaded at rest (the VAE stays
+            # resident; the text encoder was already offloaded after conditioning).
+            memory.offload("dit")
             return pixels
 
     def _denoise(

--- a/thenoise/runtime.py
+++ b/thenoise/runtime.py
@@ -28,6 +28,7 @@ class Settings:
     model, so its directory is NOT a model-load parameter.
     """
     device: str = "cuda"      # ROCm torch aliases cuda -> hip
+    offload_device: str = ""   # empty = auto-detect from safetensors size vs VRAM
     host: str = "127.0.0.1"
     port: int = 8000
     upscaler_dir: str = ""     # directory of pixel-domain upscaler models
@@ -80,6 +81,7 @@ class Runtime:
             vae_path=paths.vae_path,
             text_encoder_path=paths.text_encoder_path,
             device=self._settings.device,
+            offload_device=self._settings.offload_device,
             lora_dir=paths.lora_dir or None,
         )
 

--- a/thenoise/utils/device.py
+++ b/thenoise/utils/device.py
@@ -14,6 +14,22 @@ def clean_memory_on_device(device: Optional[Union[str, torch.device]]):
     elif device.type == "mps":  # not tested
         torch.mps.empty_cache()
 
+
+def get_device_memory(device: Optional[Union[str, torch.device]]) -> Optional[int]:
+    """Total device memory in bytes for a compute device, or ``None`` if unknown.
+
+    Only ``cuda`` (ROCm aliases ``cuda`` -> hip) is currently supported; other
+    device kinds (cpu, meta, mps, xpu) return ``None``. Used by the offload
+    auto-detection, which compares the expected resident weight bytes against this.
+    """
+    if device is None:
+        return None
+    if isinstance(device, str):
+        device = torch.device(device)
+    if device.type == "cuda":
+        return torch.cuda.get_device_properties(device).total_memory
+    return None
+
 def synchronize_device(device: Optional[Union[str, torch.device]]):
     if device is None:
         return


### PR DESCRIPTION
Support offloading weight to RAM to better serve systems with dGPUs. Currently, there is no SSD-streaming or similar, the paradigm is strictly RAM/VRAM

Pairs well with int8 models and text encoders a repository containing both is https://huggingface.co/supermind/int8_convrot_models